### PR TITLE
Feature/triage mg redflags guardrail

### DIFF
--- a/.agents/skills/saluddeuna-backlog-hu003/SKILL.md
+++ b/.agents/skills/saluddeuna-backlog-hu003/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: saluddeuna-backlog-hu003
+description: Project context skill for HU-003 — AI-guided Triage (General Medicine). Use when planning, implementing, or reviewing the triage feature to obtain the validated product purpose, API contracts, workflows, DoR/DoD, guardrails (no-diagnosis), SLO (<15s analysis), required data/env (MongoDB dev, Gemini API key or mock, RAG corpus), testing expectations, and integration guidance for backend, mobile and QA teams.
+---
+
+# HU-003 — Skill Playbook: Triage Guiado por IA (Medicina General)
+
+**Fecha:** 2026-04-05  
+**Repo(s):** Backend + Wiki (y luego App Paciente RN; web no aplica)  
+**Historia (fuente de verdad):** HU-003 – Triage Guiado por IA para Medicina General (E2, F2.1)  
+**Prioridad:** Must — **Estimación:** 8 SP  
+**Restricción clave:** *No diagnóstico / no prescripción* (guardrail obligatorio)
+
+---
+
+## 0) Objetivo del skill
+
+Implementar el flujo completo de triage de Medicina General:
+
+1) Crear sesión triage  
+2) Guardar respuestas estructuradas (máx 10 preguntas)  
+3) Ejecutar análisis (Gemini + RAG + RedFlagsEngine) en < 15s  
+4) Responder prioridad + red flags **sin lenguaje diagnóstico**  
+5) Crear caso automáticamente en la **cola médica** con esa prioridad  
+6) Persistir sesión en MongoDB con estado `COMPLETED` o `FAILED`
+
+Este documento se debe usar como checklist permanente en desarrollo, QA y PRs.
+
+---
+
+## 1) Contrato funcional (no cambiar sin decisión de equipo)
+
+### Endpoints v1 requeridos (backend)
+- `POST /v1/triage/sessions`
+- `POST /v1/triage/sessions/{id}/answers`
+- `POST /v1/triage/sessions/{id}/analyze`
+
+### Reglas MVP
+- Máximo 10 preguntas.
+- Respuestas **solo**: selección múltiple o escala numérica (sin texto libre).
+- Guardrail obligatorio: no retornar ni persistir lenguaje de diagnóstico/prescripción.
+- Si análisis falla: sesión queda `FAILED` con mensaje de error.
+- `COMPLETED` es requisito para que E4 (ClinicalSummary) consuma la sesión.
+
+### Resultado esperado del analyze
+- `priority`: `LOW | MODERATE | HIGH`
+- `redFlags`: lista estructurada (catálogo v1)
+- `nextSteps`: recomendaciones genéricas (no diagnóstico)
+
+---
+
+## 2) Escenarios Gherkin (deben guiar pruebas)
+
+### Scenario: Triage principal con priorización
+Given un paciente autenticado en Medicina General  
+When responde el cuestionario guiado completo  
+Then el sistema genera prioridad LOW, MODERATE o HIGH  
+And guarda evidencia de síntomas y factores de riesgo  
+And el caso entra en la cola médica con esa prioridad
+
+### Scenario: Triage alterno incompleto
+Given un paciente que abandona el cuestionario  
+When intenta enviar respuestas incompletas  
+Then el sistema solicita completar campos obligatorios  
+And no ejecuta análisis de prioridad
+
+### Scenario: Guardrail de no-diagnóstico activo
+Given un cuestionario completado con síntomas que podrían inducir diagnóstico  
+When el motor IA procesa las respuestas  
+Then la respuesta no contiene lenguaje de diagnóstico ni prescripción  
+And el resultado solo describe nivel de urgencia y síntomas reportados
+
+### Scenario: Tiempo de análisis dentro del SLO
+Given una sesión de triage completada  
+When se dispara el análisis con POST /v1/triage/sessions/{id}/analyze  
+Then el sistema retorna la respuesta en menos de 15 segundos  
+And el log registra la latencia del análisis IA
+
+---
+
+## 3) Checklist de Definition of Ready (DoR)
+
+- [ ] Historia Como/Quiero/Para OK
+- [ ] E2 / F2.1 confirmados
+- [ ] Must (MoSCoW)
+- [ ] Gherkin principal + alternos documentados
+- [ ] Dependencias: HU-001 lista (auth paciente)
+- [ ] Estimación 8 SP acordada
+- [ ] Ambientes listos: MongoDB dev, API key Gemini dev, corpus RAG base
+- [ ] Riesgos: prompts iterativos y guardrail
+- [ ] Guardrail acordado por el equipo
+- [ ] Estructura del cuestionario MG v1 (máx 10) acordada
+- [ ] Responsable validación funcional definido
+
+---
+
+## 4) Checklist de Definition of Done (DoD)
+
+Backend:
+- [ ] Endpoints `/triage/sessions`, `/answers`, `/analyze` implementados
+- [ ] Integración IA (Gemini + RAG) con prompts versionados en repo
+- [ ] Guardrail no-diagnóstico implementado y probado
+- [ ] RedFlagsEngine MG implementado con catálogo v1
+- [ ] Sesión persistida en MongoDB con contrato ClinicalSummary
+- [ ] Unit tests TriageService >= 80% y verdes
+- [ ] Integration tests de los 3 endpoints verdes
+- [ ] Logs de auditoría: correlation_id, specialty, priority, latency_ms
+- [ ] SLO < 15s verificado (mín. 10 ejecuciones en test env)
+
+Mobile RN:
+- [ ] Pantalla de triage paso a paso con barra de progreso
+- [ ] Manejo de HIGH: mensaje destacado + opción contactar médico
+
+Doc:
+- [ ] Wiki actualizada (endpoints, contrato, política guardrail)
+- [ ] Demo aprobada por el equipo
+
+---
+
+## 5) Plan de ejecución por tareas (orden recomendado)
+
+### T1 — Alinear contrato y estados (diseño rápido)
+**Entregable:** contrato JSON + estados + enums definidos.
+
+- Definir estados de sesión: `DRAFT | IN_PROGRESS | COMPLETED | FAILED`
+- Definir `priority`: `LOW | MODERATE | HIGH`
+- Definir catálogo mínimo de red flags MG v1 (ej: dolor torácico, disnea severa, signos neurológicos focales, etc. en formato estructurado)
+- Definir estructura de preguntas MG (máx 10) y tipo de respuesta (choice/scale)
+
+**Criterio de salida:** documento de contrato + enums aprobados.
+
+---
+
+### T2 — Persistencia MongoDB: TriageSession schema (backend)
+**Entregable:** `triage/schemas/triage-session.schema.ts`
+
+Campos mínimos:
+- `patientId`
+- `specialty = GENERAL_MEDICINE`
+- `status`
+- `questionsVersion`
+- `answers[]` (estructurado: questionId + selectedOptionIds | numericValue)
+- `analysis` (priority, redFlags, nextSteps, aiLatencyMs, providerMetadata)
+- `error` (si FAILED)
+- timestamps
+
+**Criterio de salida:** schema + índices + tests unitarios de mapeo.
+
+---
+
+### T3 — Endpoint POST /v1/triage/sessions (backend)
+**Entregable:** crea sesión y retorna `sessionId` + `questionnaire` (o al menos metadata).
+
+- Autenticación requerida (paciente)
+- Valida que specialty sea Medicina General
+- Inicializa status `IN_PROGRESS`
+- Retorna cantidad total de preguntas (para progreso)
+
+**Criterio de salida:** integration test “create session”.
+
+---
+
+### T4 — Endpoint POST /v1/triage/sessions/{id}/answers (backend)
+**Entregable:** guarda respuestas por pasos.
+
+- Valida que la sesión pertenezca al paciente (ownership)
+- Valida formato (sin texto libre)
+- Valida completitud por paso o al final (según contrato)
+- No permite `analyze` si faltan obligatorias
+
+**Criterio de salida:** integration test “answers incompletas -> 400”.
+
+---
+
+### T5 — RedFlagsEngine MG (backend)
+**Entregable:** motor determinístico (reglas) que produce red flags + severidad.
+
+- Input: answers estructuradas
+- Output: `redFlags[]` (id, label, severity, evidence)
+
+**Criterio de salida:** unit tests por regla.
+
+---
+
+### T6 — IA Orchestrator (Gemini + RAG) + Prompts versionados (backend)
+**Entregable:** servicio IA que produce resumen no-diagnóstico.
+
+- Input: answers + contexto RAG (si aplica)
+- Output: explicación neutral del nivel de urgencia + nextSteps
+- Prompts versionados en repo (carpeta `src/triage/prompts/` o similar)
+- Timeouts: hard limit < 15s (configurable)
+
+**Criterio de salida:** mock de proveedor en tests + medición de latency.
+
+---
+
+### T7 — Guardrail no-diagnóstico (backend)
+**Entregable:** filtro/validador que:
+- inspecciona respuesta IA
+- elimina/bloquea frases de diagnóstico/prescripción
+- **prohíbe persistir** texto prohibido
+
+Estrategia mínima MVP:
+- Lista de términos prohibidos (diagnóstico/prescripción) + regex
+- Post-procesamiento + fallback seguro (“No podemos dar diagnóstico… prioridad… siguientes pasos…”)
+
+**Criterio de salida:** tests con ejemplos “induce diagnóstico” y verificación de sanitización.
+
+---
+
+### T8 — Endpoint POST /v1/triage/sessions/{id}/analyze (backend)
+**Entregable:** ejecuta pipeline:
+1) Validar sesión completa  
+2) RedFlagsEngine  
+3) IA Orchestrator  
+4) Guardrail  
+5) Determinar `priority` final (reglas pueden elevar a HIGH)  
+6) Guardar `analysis` y set `COMPLETED`  
+7) Crear caso en cola médica (consultations)
+
+**Criterio de salida:** integration test “analyze ok -> COMPLETED” + “analyze falla -> FAILED”.
+
+---
+
+### T9 — Crear caso en cola médica (integración consultations)
+**Entregable:** persistir “case” consultable por `GET /v1/consultations/queue`.
+
+- Definir entidad/colección `consultations` (si no existe) o estructura equivalente.
+- Debe guardar: patientId, triageSessionId, priority, status, timestamps.
+- La cola debe ordenar por prioridad y antigüedad (si aplica).
+
+**Criterio de salida:** integration test: after analyze, queue devuelve item.
+
+---
+
+### T10 — Observabilidad: logs + métricas mínimas
+**Entregable:** logs estructurados:
+- `endpoint_or_event = triage.session.created | triage.answers.saved | triage.analyze.completed | triage.analyze.failed`
+- `correlation_id`, `latency_ms`, `priority`, `specialty`
+
+**Criterio de salida:** verificación en logs de test.
+
+---
+
+### T11 — App Paciente (React Native) (cuando aplique)
+**Entregable:** UI triage MG paso a paso:
+- progreso X/Y
+- opciones (multi) y escala
+- submit por paso
+- pantalla resultado con HIGH destacado
+
+**Criterio de salida:** demo end-to-end.
+
+---
+
+## 6) Políticas innegociables (guardrails)
+
+- No se retorna diagnóstico ni prescripción.
+- No se guarda en DB texto con lenguaje diagnóstico.
+- Solo se retorna urgencia y siguiente paso genérico.
+- Límite 10 preguntas.
+- Sin texto libre MVP.
+
+---
+
+## 7) Evidencia requerida en PRs
+
+Cada PR relacionado a HU-003 debe:
+- referenciar este skill (link)
+- listar tareas cubiertas (T1..T11)
+- adjuntar resultados de tests (unit + integration)
+- declarar cambios en contrato/endpoints
+
+---
+
+## 8) Notas de implementación (para evitar deuda)
+- Separar: `TriageController` -> `TriageService` (sin lógica en controller)
+- DTOs con class-validator + ValidationPipe global
+- Timeouts robustos al proveedor IA
+- `FAILED` siempre persistido con causa “segura” para el usuario (sin detalles sensibles)
+
+---
+**Fin del skill.**

--- a/.env.development.example
+++ b/.env.development.example
@@ -10,7 +10,7 @@ JWT_REFRESH_EXPIRES_IN=7d
 REFRESH_MAX_ACTIVE_SESSIONS=3
 
 # Frontend origins for local development
-CORS_ORIGINS_PATIENT=http://localhost:5173
+CORS_ORIGINS_PATIENT=http://localhost:5173,http://localhost:8081,http://127.0.0.1:8081
 CORS_ORIGINS_STAFF=http://localhost:5174
 
 # Optional bootstrap admin

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ pids
 *.seed
 *.pid.lock
 
+# Local MongoDB data
+.mongo-data/
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Modulos cargados en `src/app.module.ts`:
 - `NotificationsModule`
 - `DashboardModule`
 - `ConsultationsModule`
+- `TriageModule`
 - `OutboxModule`
 - `RedisModule`
 
@@ -228,6 +229,9 @@ Sesiones autenticadas:
 | `POST /v1/doctors/me/rethus-resubmit`            | No      | Si           | `DOCTOR`                                                                                   |
 | `GET /v1/dashboard/technical`                    | No      | Si           | `ADMIN`                                                                                    |
 | `GET /v1/dashboard/business`                     | No      | Si           | `ADMIN`                                                                                    |
+| `POST /v1/triage/sessions`                       | No      | Si           | `PATIENT`                                                                                  |
+| `POST /v1/triage/sessions/:sessionId/answers`    | No      | Si           | `PATIENT`                                                                                  |
+| `POST /v1/triage/sessions/:sessionId/analyze`    | No      | Si           | `PATIENT`                                                                                  |
 | `POST /v1/admin/ai/health-check`                 | No      | Si           | `ADMIN`                                                                                    |
 | `GET /v1/health`                                 | Si      | No           | -                                                                                          |
 | `GET /v1/ready`                                  | Si      | No           | -                                                                                          |
@@ -360,6 +364,181 @@ Body de update (opcional):
   "gender": "FEMALE"
 }
 ```
+
+### 5.1) HU-003 - Triage guiado por IA (Medicina General)
+
+Trazabilidad:
+
+- Historia: HU-003
+- Sprint: backlog T-003-05, T-003-07, T-003-08, T-003-09 y T-003-10
+
+Nota de rutas:
+
+- El backlog usa rutas base tipo `apps/api/src/...`; en este repositorio el equivalente real es `src/...`.
+
+#### POST /v1/triage/sessions
+
+Requiere JWT con rol `PATIENT`.
+
+Request:
+
+```json
+{
+  "specialty": "GENERAL_MEDICINE"
+}
+```
+
+Response (201):
+
+```json
+{
+  "sessionId": "67f123...",
+  "specialty": "GENERAL_MEDICINE",
+  "status": "IN_PROGRESS",
+  "questions": [
+    {
+      "questionId": "MG-Q1",
+      "questionText": "Que sintoma principal presentas hoy?"
+    }
+  ],
+  "totalQuestions": 5,
+  "answeredCount": 0,
+  "remainingQuestions": 5,
+  "progressPercent": 0,
+  "nextQuestionId": "MG-Q1",
+  "isComplete": false
+}
+```
+
+Errores:
+
+- 400: payload invalido.
+- 409: ya existe una sesion `IN_PROGRESS` para el paciente y la especialidad.
+
+#### POST /v1/triage/sessions/:sessionId/answers
+
+Requiere JWT con rol `PATIENT`.
+
+Request:
+
+```json
+{
+  "answers": [
+    { "questionId": "MG-Q1", "answerValue": "cefalea" },
+    { "questionId": "MG-Q2", "answerValue": "2 dias" },
+    { "questionId": "MG-Q3", "answerValue": 4 },
+    { "questionId": "MG-Q4", "answerValue": "no" },
+    { "questionId": "MG-Q5", "answerValue": "no" }
+  ]
+}
+```
+
+Response (200):
+
+```json
+{
+  "sessionId": "67f123...",
+  "answersCount": 5,
+  "isComplete": true,
+  "totalQuestions": 5,
+  "answeredCount": 5,
+  "remainingQuestions": 0,
+  "progressPercent": 100,
+  "nextQuestionId": null
+}
+```
+
+Errores:
+
+- 400: `questionId` invalido o sesion fuera de estado `IN_PROGRESS`.
+- 404: sesion inexistente o no pertenece al paciente autenticado.
+
+#### POST /v1/triage/sessions/:sessionId/analyze
+
+Requiere JWT con rol `PATIENT`.
+
+Response (200):
+
+```json
+{
+  "sessionId": "67f123...",
+  "priority": "HIGH",
+  "redFlags": [
+    {
+      "code": "RF-MG-001",
+      "specialty": "GENERAL_MEDICINE",
+      "severity": "CRITICAL",
+      "evidence": "Combinacion de dolor toracico y dificultad respiratoria reportada"
+    }
+  ],
+  "message": "Se detectaron signos de alarma. Tu caso fue priorizado para atencion medica.",
+  "highPriorityAlert": true
+}
+```
+
+Errores:
+
+- 404: sesion inexistente o no pertenece al paciente autenticado.
+- 422: sesion incompleta (faltan respuestas obligatorias).
+- 503: fallo operativo del proveedor IA durante analisis de Medicina General.
+
+#### Contrato TriageSession (persistencia)
+
+```json
+{
+  "_id": "ObjectId",
+  "patientId": "ObjectId",
+  "specialty": "GENERAL_MEDICINE | ODONTOLOGY",
+  "status": "IN_PROGRESS | COMPLETED | FAILED",
+  "answers": [
+    {
+      "questionId": "MG-Q1",
+      "questionText": "Que sintoma principal presentas hoy?",
+      "answerValue": "valor mixto (string/number/boolean)",
+      "answeredAt": "2026-04-05T14:10:00.000Z"
+    }
+  ],
+  "analysis": {
+    "priority": "LOW | MODERATE | HIGH",
+    "redFlags": [
+      {
+        "code": "RF-MG-001",
+        "specialty": "GENERAL_MEDICINE",
+        "severity": "CRITICAL | WARNING | INFO",
+        "evidence": "texto"
+      }
+    ],
+    "aiSummary": "string opcional",
+    "analysisDurationMs": 1234,
+    "guardrailApplied": true
+  },
+  "completedAt": "2026-04-05T14:10:01.000Z",
+  "createdAt": "2026-04-05T14:09:00.000Z",
+  "updatedAt": "2026-04-05T14:10:01.000Z"
+}
+```
+
+#### Catalogo Red Flags Medicina General v1
+
+Fuente: `src/triage/rules/red-flags-mg.json`
+
+- RF-MG-001: dolor toracico + dificultad respiratoria -> `CRITICAL`
+- RF-MG-002: perdida de consciencia o sincope -> `CRITICAL`
+- RF-MG-003: fiebre > 39C + rigidez de nuca -> `CRITICAL`
+- RF-MG-004: dolor abdominal intenso de inicio subito -> `CRITICAL`
+- RF-MG-005: alteraciones visuales repentinas -> `WARNING`
+
+#### Politica de guardrail
+
+Fuente: `src/triage/rules/guardrail-rules.json`
+
+- Filtro obligatorio de texto IA para categorias: diagnostico, prescripcion y afirmacion clinica.
+- Contrato tecnico del guardrail: `check(text) -> { safe, violations[] }`.
+- Si `safe=false`:
+  - `analysis.aiSummary` no se persiste.
+  - `analysis.guardrailApplied=true`.
+  - Se emite log estructurado `WARN` con `correlation_id`, `triage_session_id` y `violations`.
+- Si `safe=true`, se conserva resumen neutral de urgencia sin diagnostico ni prescripcion.
 
 ### 6) Bandeja admin de doctores
 

--- a/docs/tareas-backlog3-6-10.MD
+++ b/docs/tareas-backlog3-6-10.MD
@@ -1,0 +1,105 @@
+# HU-003 Remaining - Execution Plan and Incremental Delivery
+
+Date: 2026-04-05
+
+## Context and source alignment
+
+- Original file was empty (`0 bytes`), so implementation was grounded on:
+  - `docs/tareas-backlog3.MD`
+  - `.agents/skills/saluddeuna-backlog-hu003/SKILL.md`
+  - `.agents/skills/saluddeuna-project-understanding/SKILL.md`
+  - `.agents/skills/nestjs-best-practices/SKILL.md`
+
+## Step-by-step execution plan (requested order)
+
+1. RedFlagsEngine
+
+- Strengthen deterministic rules for General Medicine without changing endpoint contracts.
+- Add tests per new rule and severity mapping.
+
+2. GuardrailService
+
+- Extract no-diagnosis/no-prescription guardrail from `TriageService` into dedicated service.
+- Keep persistence contract: never store forbidden AI text.
+
+3. Mobile triage flow (backend contract)
+
+- Enrich triage responses with mobile-friendly progress metadata while preserving existing fields:
+  - `totalQuestions`, `answeredCount`, `remainingQuestions`, `progressPercent`, `nextQuestionId`, `isComplete`
+- Enrich analyze response with `highPriorityAlert`.
+
+4. Unit tests
+
+- Update and run triage module unit suite after each increment.
+
+5. Integration tests
+
+- Execute e2e command and record evidence.
+
+6. Documentation
+
+- Record implementation status, contracts, and test evidence in this file.
+
+## Incremental implementation status
+
+### 1) RedFlagsEngine - completed
+
+- Updated:
+  - `src/triage/services/red-flags.engine.ts`
+- Added deterministic MG rules:
+  - `RF-MG-004` (neurologic emergency symptom patterns) -> `CRITICAL`
+  - `RF-MG-005` (prolonged duration >= 7 days) -> `WARNING`
+- Kept previous rules and added de-duplication by code.
+- Validation:
+  - `npx jest src/triage/services/red-flags.engine.spec.ts --runInBand` -> PASS
+
+### 2) GuardrailService - completed
+
+- Added:
+  - `src/triage/services/guardrail.service.ts`
+  - `src/triage/services/guardrail.service.spec.ts`
+- Integrated into:
+  - `src/triage/triage.module.ts`
+  - `src/triage/triage.service.ts`
+- Removed inline guardrail logic from `TriageService`.
+- Validation:
+  - `npx jest src/triage/services/guardrail.service.spec.ts src/triage/triage.service.spec.ts --runInBand` -> PASS
+
+### 3) Mobile triage flow (backend) - completed
+
+- Updated response contracts in `TriageService`:
+  - `createSession`: now includes progress metadata
+  - `saveAnswers`: now includes progress metadata (keeps `answersCount` and `isComplete`)
+  - `analyzeSession`: now includes `highPriorityAlert`
+- Updated tests to validate new contract:
+  - `src/triage/triage.service.spec.ts`
+  - `test/e1.e2e-spec.ts` (triage assertions adapted)
+- Validation:
+  - `npx jest src/triage/triage.service.spec.ts src/triage/triage.controller.spec.ts --runInBand` -> PASS
+
+### 4) Unit tests - completed
+
+- Full triage unit suite:
+  - `npx jest src/triage --runInBand` -> PASS
+  - Result: 5 suites, 28 tests passed
+
+### 5) Integration tests - blocked by environment
+
+- Command executed:
+  - `npx jest --config ./test/jest-e2e.json --runInBand --testNamePattern "triage/sessions"`
+- Result:
+  - FAIL due `spawn EPERM` while starting `MongoMemoryReplSet` (mongodb-memory-server)
+  - This is an environment restriction, not a triage business-rule assertion failure.
+
+### 6) Documentation - completed
+
+- This file now contains execution plan, implementation trace, and validation evidence.
+
+## Business rules and contract compliance checklist
+
+- No-diagnosis/no-prescription guardrail: enforced via `GuardrailService`.
+- Triage ownership and state validation: preserved.
+- Priority override by red flags: preserved (`CRITICAL` => `HIGH`; `WARNING` can elevate).
+- Consultation creation on successful analyze: preserved.
+- Backward compatibility:
+  - Existing keys are preserved; new mobile keys are additive.

--- a/docs/tareas-backlog3-de5-a10.MD
+++ b/docs/tareas-backlog3-de5-a10.MD
@@ -1,0 +1,141 @@
+## T-003-05 – Implementación del RedFlagsEngine para Medicina General
+
+Implementar el motor centralizado de detección de red flags:
+- Clase RedFlagsEngine con método estático evaluate(answers: TriageAnswer[], specialty: Specialty): RedFlag[].
+- Catálogo de red flags Medicina General (mínimo 5, versionado en archivo JSON separado):
+    · RF-MG-001: dolor torácico + dificultad respiratoria → CRITICAL
+    · RF-MG-002: pérdida de consciencia o síncope → CRITICAL
+    · RF-MG-003: fiebre > 39°C + rigidez de nuca → CRITICAL
+    · RF-MG-004: dolor abdominal intenso de inicio súbito → CRITICAL
+    · RF-MG-005: alteraciones visuales repentinas → WARNING
+- El catálogo se carga desde apps/api/src/triage/rules/red-flags-mg.json para facilitar
+  actualización sin modificar código.
+- La función es pura (sin efectos secundarios) y testeable de forma aislada.
+- Cobertura de pruebas unitarias >= 90%.
+Ubicar en: apps/api/src/triage/engines/red-flags.engine.ts
+
+Criterios de aceptación de la tarea:
+
+El motor detecta correctamente cada uno de los 5 red flags de MG con sus respectivos síntomas disparadores.
+La función retorna un array vacío cuando no hay combinaciones de riesgo.
+El catálogo es modificable sin cambiar el código del motor.
+Cobertura de pruebas >= 90% en CI.
+
+## T-003-06 – Implementación del cuestionario de Medicina General y pantalla de triage en React Native
+
+Implementar el flujo de triage de Medicina General en la app móvil:
+
+TriageSelectionScreen:
+- Pantalla de selección de especialidad (Medicina General / Odontología).
+- Botón "Iniciar Triage" llama a POST /v1/triage/sessions con la especialidad seleccionada.
+- Al éxito, navega a TriageQuestionnaireScreen.
+
+TriageQuestionnaireScreen (Medicina General):
+- Muestra las preguntas del cuestionario una a una con barra de progreso (paso X de N).
+- Tipos de respuesta soportados: selección única, selección múltiple, escala numérica (1-10).
+- Botón "Siguiente" guarda la respuesta actual (POST /v1/triage/sessions/{id}/answers).
+- Botón "Finalizar y analizar" (visible solo cuando isComplete=true) dispara el análisis.
+
+TriageResultScreen:
+- Muestra la prioridad resultante con color: verde (LOW), amarillo (MODERATE), rojo (HIGH).
+- Lista de red flags detectados con su descripción.
+- Para prioridad HIGH: banner de advertencia con recomendación de atención urgente.
+- Botón "Ver mi caso en consultas" navega al listado de consultas del paciente.
+
+Ubicar en: apps/mobile/src/screens/triage/
+
+Criterios de aceptación de la tarea:
+
+El flujo completo (selección → cuestionario → resultado) funciona sin errores.
+La barra de progreso refleja el avance correcto.
+El banner HIGH se muestra correctamente cuando la prioridad es HIGH.
+La app no crashea con ninguna respuesta válida del backend.
+Los errores del backend se muestran con mensajes comprensibles al usuario.
+
+
+## T-003-07 – Implementación del GuardrailService para respuestas IA
+
+Implementar el servicio de guardrail para respuestas del modelo IA:
+- Clase GuardrailService con método check(text: string): { safe: boolean, violations: string[] }.
+- Lista de términos y patrones prohibidos (versionada en apps/api/src/triage/rules/guardrail-rules.json):
+    · Términos de diagnóstico: "diagnóstico de", "padece de", "tiene [enfermedad]", etc.
+    · Términos de prescripción: "tomar [medicamento]", "administrar", "recetar", etc.
+    · Patrones de afirmación clínica: "es [condición médica]", "sufre de", etc.
+- Si safe=false: registrar alerta en log estructurado con nivel WARN, los violations encontrados
+  y el correlation ID de la sesión.
+- El GuardrailService es independiente del modelo IA; puede reutilizarse en otros módulos.
+Ubicar en: apps/api/src/triage/services/guardrail.service.ts
+
+Criterios de aceptación de la tarea:
+
+El servicio detecta correctamente textos con lenguaje de diagnóstico (al menos 10 casos de prueba).
+El servicio clasifica como safe textos con lenguaje de priorización/urgencia sin diagnóstico.
+Cada violación queda registrada en el log con el correlation ID.
+
+
+## T-003-08 – Pruebas unitarias del TriageService y RedFlagsEngine MG
+
+Escribir pruebas unitarias con Jest:
+TriageService:
+- createSession: creación exitosa con specialty válida.
+- createSession: conflicto con sesión IN_PROGRESS existente → ConflictException.
+- saveAnswers: guardado exitoso; retorna isComplete correcto.
+- saveAnswers: sesión no encontrada → NotFoundException.
+- analyzeSession: sesión incompleta → UnprocessableEntityException.
+- analyzeSession: red flag CRITICAL → override a prioridad HIGH.
+- analyzeSession: guardrail activo → aiSummary descartado, guardrailApplied=true.
+
+RedFlagsEngine:
+- Cada uno de los 5 red flags de MG: verificar detección correcta.
+- Combinación sin red flags → array vacío.
+- Combinación con múltiples red flags → todos retornados correctamente.
+
+GuardrailService:
+- Texto con diagnóstico → safe=false con violations.
+- Texto con prioridad/urgencia → safe=true.
+
+Cobertura mínima objetivo: 80% de TriageService, 90% de RedFlagsEngine.
+Ubicar en: apps/api/src/triage/triage.service.spec.ts y red-flags.engine.spec.ts
+
+Criterios de aceptación de la tarea:
+
+Todos los tests pasan en CI.
+Cobertura >= 80% TriageService, >= 90% RedFlagsEngine.
+No hay dependencias reales de base de datos ni de API IA en estas pruebas.
+
+## T-003-09 – Pruebas de integración de los endpoints de triage MG
+
+Pruebas de integración con supertest + MongoMemoryServer (Gemini mockeado):
+- POST /v1/triage/sessions con specialty=GENERAL_MEDICINE → 201 con sessionId y preguntas.
+- POST /v1/triage/sessions con sesión IN_PROGRESS existente → 409.
+- POST /v1/triage/sessions/{id}/answers con respuestas válidas → 200 con isComplete.
+- POST /v1/triage/sessions/{id}/answers con sessionId inexistente → 404.
+- POST /v1/triage/sessions/{id}/analyze con sesión completa → 200 con prioridad y redFlags.
+- POST /v1/triage/sessions/{id}/analyze: mock de Gemini retorna diagnóstico → guardrail activo.
+- POST /v1/triage/sessions/{id}/analyze: mock activa RF-MG-001 → prioridad=HIGH.
+- POST /v1/triage/sessions/{id}/analyze con sesión incompleta → 422.
+Ubicar en: apps/api/test/triage-mg.e2e-spec.ts
+
+Criterios de aceptación de la tarea:
+
+Todos los tests de integración pasan en CI de forma aislada.
+El mock de Gemini permite probar el guardrail sin llamadas reales a la API.
+El flujo completo (crear → responder → analizar) se cubre end-to-end.
+
+
+## T-003-10 – Documentación técnica del módulo de triage MG en Wiki
+
+Actualizar la Wiki con:
+- POST /v1/triage/sessions: request, response 201, errores 400/409.
+- POST /v1/triage/sessions/{id}/answers: request, response 200 con isComplete, errores 400/404.
+- POST /v1/triage/sessions/{id}/analyze: request, response 200 con prioridad y redFlags, errores 404/422.
+- Contrato completo del objeto TriageSession con todos los campos.
+- Catálogo de red flags de Medicina General v1.
+- Política de guardrail: qué se filtra, cómo se registra, cómo se gestiona el resultado.
+- Referencia a HU-003 y al sprint de implementación.
+
+Criterios de aceptación de la tarea:
+
+La Wiki refleja los contratos reales de los endpoints implementados.
+Un nuevo desarrollador puede implementar un cliente del triage sin leer el código fuente.
+La política de guardrail es comprensible para el equipo de producto y clínico.

--- a/docs/tareas-backlog3.MD
+++ b/docs/tareas-backlog3.MD
@@ -1,5 +1,4 @@
 the markdown file and the skill saluddeuna-backlog-hu003. Create a step-by-step execution plan and implement it incrementally. Focus on one task at a time (schema → endpoints → services), validate each step, and ensure DTOs, guards, and business rules strictly match the specification.
-Rompiste la integridad del archivo markdown, hazlo en un solo bloque
 # Triage Module – Technical Specification (HU003)
 
 ## T-003-01 – Diseño del modelo TriageSession en MongoDB

--- a/docs/tareas-backlog3.MD
+++ b/docs/tareas-backlog3.MD
@@ -1,6 +1,4 @@
 
-the markdown file and the skill saluddeuna-backlog-hu003. Create a step-by-step execution plan and implement it incrementally. Focus on one task at a time (schema → endpoints → services), validate each step, and ensure DTOs, guards, and business rules strictly match the specification.
-
 # Triage Module – Technical Specification (HU003)
 
 ## T-003-01 – Diseño del modelo TriageSession en MongoDB

--- a/docs/tareas-backlog3.MD
+++ b/docs/tareas-backlog3.MD
@@ -1,5 +1,3 @@
-the markdown file and the skill saluddeuna-backlog-hu003. Create a step-by-step execution plan and implement it incrementally. Focus on one task at a time (schema → endpoints → services), validate each step, and ensure DTOs, guards, and business rules strictly match the specification.
-Rompiste la integridad del archivo markdown, hazlo en un solo bloque
 # Triage Module – Technical Specification (HU003)
 
 ## T-003-01 – Diseño del modelo TriageSession en MongoDB

--- a/docs/tareas-backlog3.MD
+++ b/docs/tareas-backlog3.MD
@@ -1,0 +1,184 @@
+the markdown file and the skill saluddeuna-backlog-hu003. Create a step-by-step execution plan and implement it incrementally. Focus on one task at a time (schema → endpoints → services), validate each step, and ensure DTOs, guards, and business rules strictly match the specification.
+Rompiste la integridad del archivo markdown, hazlo en un solo bloque
+# Triage Module – Technical Specification (HU003)
+
+## T-003-01 – Diseño del modelo TriageSession en MongoDB
+
+Crear el schema Mongoose para el modelo `TriageSession` con los siguientes campos:
+
+- `_id`: ObjectId generado automáticamente
+- `patientId`: referencia a Patient, requerido
+- `specialty`: String, enum ['GENERAL_MEDICINE', 'DENTISTRY'], requerido
+- `status`: String, enum ['IN_PROGRESS', 'COMPLETED', 'FAILED'], default 'IN_PROGRESS'
+- `answers`: Array de objetos con:
+  - `questionId`
+  - `questionText`
+  - `answerValue`
+  - `answeredAt`
+- `analysis`: Objeto opcional con:
+  - `priority`: enum ['LOW', 'MODERATE', 'HIGH']
+  - `redFlags`: Array de RedFlag
+  - `aiSummary`: String opcional, sin diagnósticos
+  - `analysisDurationMs`: Number
+  - `guardrailApplied`: Boolean
+- `completedAt`: Date opcional
+- `createdAt`, `updatedAt`: timestamps automáticos
+
+### Sub-documento RedFlag
+
+- `code`: String requerido (ej: RF-MG-001)
+- `specialty`: enum ['GENERAL_MEDICINE', 'DENTISTRY']
+- `severity`: enum ['CRITICAL', 'WARNING', 'INFO']
+- `evidence`: String
+
+### Requerimientos adicionales
+
+- Índice compuesto en `(patientId, status)`
+- Ubicación: `apps/api/src/triage/schemas/triage-session.schema.ts`
+
+### Criterios de aceptación
+
+- Schema exportado correctamente
+- Estado por defecto: IN_PROGRESS
+- Validación correcta de enums en answers y redFlags
+- Índice verificado en MongoDB local
+
+---
+
+## T-003-02 – Endpoint POST /v1/triage/sessions
+
+### Configuración
+
+- Módulo: TriageModule
+- Ruta: POST /v1/triage/sessions
+- Seguridad: JwtAuthGuard + rol PACIENTE
+
+### DTO
+
+CreateTriageSessionDto {
+  specialty: 'GENERAL_MEDICINE' | 'DENTISTRY'
+}
+
+### Lógica
+
+1. Validar que no exista sesión IN_PROGRESS para el mismo paciente y especialidad  
+   Si existe: HTTP 409  
+2. Crear sesión con status IN_PROGRESS  
+3. Retornar HTTP 201 con:
+   - sessionId
+   - specialty
+   - status
+   - questions[]  
+
+El campo `questions[]` proviene del repositorio de preguntas
+
+### Ubicación
+
+`apps/api/src/triage/`
+
+### Criterios de aceptación
+
+- Retorna 201 con datos correctos
+- Retorna 409 si ya existe sesión activa
+- Retorna 400 si specialty inválido
+- Seguridad: 401 sin token, 403 sin rol adecuado
+
+---
+
+## T-003-03 – Endpoint POST /v1/triage/sessions/{sessionId}/answers
+
+### Configuración
+
+- Ruta: POST /v1/triage/sessions/{sessionId}/answers
+- Seguridad: JwtAuthGuard + rol PACIENTE
+
+### DTO
+
+SaveTriageAnswersDto {
+  answers: [{ questionId, answerValue }]
+}
+
+### Lógica
+
+1. Validar existencia y propiedad de la sesión → 404  
+2. Validar status IN_PROGRESS → 400 si no  
+3. Validar questionIds contra la especialidad  
+4. Actualizar answers  
+5. Retornar HTTP 200:
+   - sessionId
+   - answersCount
+   - isComplete  
+
+Permite envíos parciales
+
+### Ubicación
+
+`apps/api/src/triage/`
+
+### Criterios de aceptación
+
+- Actualización correcta de respuestas
+- 404 si no existe o no pertenece al paciente
+- 400 si estado inválido
+- isComplete correcto
+
+---
+
+## T-003-04 – Endpoint POST /v1/triage/sessions/{sessionId}/analyze
+
+### Configuración
+
+- Ruta: POST /v1/triage/sessions/{sessionId}/analyze
+- Seguridad: JwtAuthGuard + rol PACIENTE
+
+### Lógica
+
+1. Validar sesión completa → HTTP 422 si no  
+2. Ejecutar RedFlagsEngine.evaluate(answers, specialty) → redFlags[]  
+3. Si specialty = GENERAL_MEDICINE:
+   - Ejecutar GeminiService.analyzeTriage(answers, redFlags)  
+4. Aplicar guardrail:
+   - Si detecta diagnóstico o prescripción → descartar aiSummary  
+   - Marcar guardrailApplied = true  
+5. Calcular prioridad:
+   - Si hay redFlag CRITICAL → HIGH  
+   - Si hay redFlag WARNING y prioridad base < MODERATE → MODERATE  
+   - En otro caso → prioridad base  
+6. Actualizar sesión:
+   - status = COMPLETED  
+   - analysis completo  
+7. Crear documento Consultation en estado PENDING  
+8. Retornar HTTP 200:
+   - sessionId
+   - priority
+   - redFlags
+   - message  
+
+### Observabilidad
+
+- Medir analysisDurationMs  
+- Alertar si > 15000 ms  
+- Registrar evento de auditoría completo  
+
+### Ubicación
+
+- `apps/api/src/triage/`
+- `apps/api/src/triage/services/gemini-triage.service.ts`
+
+### Criterios de aceptación
+
+- Retorna prioridad válida y red flags  
+- 422 si sesión incompleta  
+- Override HIGH correcto  
+- Guardrail bloquea contenido inválido  
+- Sesión queda en COMPLETED  
+- Consultation creada automáticamente  
+- Latencia registrada y alertada  
+
+---
+
+## Resumen
+
+Se define el modelo de datos, endpoints y lógica completa del flujo de triage, incluyendo persistencia, validaciones, análisis con IA, motor de reglas, seguridad y observabilidad.
+
+---

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": ["triage/rules/*.json"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2741,6 +2741,16 @@
         }
       }
     },
+    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.16",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.16.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,12 @@
         "@nestjs/bullmq": "^11.0.4",
         "@nestjs/common": "^11.0.15",
         "@nestjs/config": "^4.0.3",
-        "@nestjs/core": "^11.1.16",
+        "@nestjs/core": "11.1.18",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/mongoose": "^11.0.4",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.16",
+        "@nestjs/swagger": "^11.2.6",
         "@nestjs/throttler": "^6.5.0",
         "bcrypt": "^6.0.0",
         "bullmq": "^5.71.0",
@@ -29,7 +30,8 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.2"
+        "rxjs": "^7.8.2",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -2186,6 +2188,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
@@ -2634,16 +2642,16 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.16.tgz",
-      "integrity": "sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==",
+      "version": "11.1.18",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.18.tgz",
+      "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.2",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },
@@ -2672,6 +2680,16 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/core/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@nestjs/jwt": {
@@ -2826,6 +2844,59 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
+      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.1",
+        "lodash": "4.17.23",
+        "path-to-regexp": "8.3.0",
+        "swagger-ui-dist": "5.31.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2993,6 +3064,13 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -4425,7 +4503,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -8207,7 +8284,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10500,6 +10576,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/mongoose": "^11.0.4",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.16",
+    "@nestjs/swagger": "^11.2.6",
     "@nestjs/throttler": "^6.5.0",
     "bcrypt": "^6.0.0",
     "bullmq": "^5.71.0",
@@ -40,7 +41,8 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -66,21 +66,23 @@ import { RedisThrottlerStorage } from './redis/redis-throttler.storage';
         ),
       }),
     }),
-    ...(process.env.REDIS_URL
-      ? [
-          BullModule.forRootAsync({
-            imports: [RedisModule],
-            inject: [ConfigService, REDIS_CONNECTION_OPTIONS],
-            useFactory: (
-              configService: ConfigService,
-              connectionOptions: unknown,
-            ) => ({
-              connection: connectionOptions as Record<string, unknown>,
-              prefix: `${configService.get<string>('redis.keyPrefix') ?? 'salud-de-una'}:bull`,
-            }),
-          }),
-        ]
-      : []),
+    BullModule.forRootAsync({
+      imports: [RedisModule],
+      inject: [ConfigService, REDIS_CONNECTION_OPTIONS],
+      useFactory: (
+        configService: ConfigService,
+        connectionOptions: unknown,
+      ) => {
+        const redisUrl = configService.get<string>('redis.url');
+
+        return {
+          connection: redisUrl
+            ? (connectionOptions as Record<string, unknown>)
+            : undefined,
+          prefix: `${configService.get<string>('redis.keyPrefix') ?? 'salud-de-una'}:bull`,
+        };
+      },
+    }),
     MongooseModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -56,7 +56,7 @@ import { RedisThrottlerStorage } from './redis/redis-throttler.storage';
       ) => ({
         throttlers: [
           {
-            ttl: 60_000,
+            ttl: 60,
             limit: 20,
           },
         ],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { BullModule } from '@nestjs/bullmq';
+import type { ConnectionOptions } from 'bullmq';
 import { MongooseModule } from '@nestjs/mongoose';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { AdminModule } from './admin/admin.module';
@@ -71,14 +72,15 @@ import { RedisThrottlerStorage } from './redis/redis-throttler.storage';
       inject: [ConfigService, REDIS_CONNECTION_OPTIONS],
       useFactory: (
         configService: ConfigService,
-        connectionOptions: unknown,
+        connectionOptions: ConnectionOptions | null,
       ) => {
-        const redisUrl = configService.get<string>('redis.url');
+        const resolvedConnection: ConnectionOptions = connectionOptions ?? {
+          host: '127.0.0.1',
+          port: 6379,
+        };
 
         return {
-          connection: redisUrl
-            ? (connectionOptions as Record<string, unknown>)
-            : undefined,
+          connection: resolvedConnection,
           prefix: `${configService.get<string>('redis.keyPrefix') ?? 'salud-de-una'}:bull`,
         };
       },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { DoctorsModule } from './doctors/doctors.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { OutboxModule } from './outbox/outbox.module';
 import { PatientsModule } from './patients/patients.module';
+import { TriageModule } from './triage/triage.module';
 import {
   REDIS_CLIENT,
   REDIS_CONNECTION_OPTIONS,
@@ -94,6 +95,7 @@ import { RedisThrottlerStorage } from './redis/redis-throttler.storage';
     NotificationsModule,
     DashboardModule,
     ConsultationsModule,
+    TriageModule,
     AdminsModule,
     OutboxModule,
   ],

--- a/src/common/filters/http-exception.filter.spec.ts
+++ b/src/common/filters/http-exception.filter.spec.ts
@@ -64,4 +64,25 @@ describe('HttpExceptionFilter', () => {
       }),
     );
   });
+
+  it('should include custom payload fields from HttpException response', () => {
+    const { host, response } = createHost({ correlationId: 'cid-2' });
+    const exception = new BadRequestException({
+      message: 'invalid payload',
+      errorCode: 'CUSTOM_CODE',
+      detail: 'extra-value',
+    });
+
+    filter.catch(exception, host);
+
+    expect(response.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: 'invalid payload',
+        errorCode: 'CUSTOM_CODE',
+        detail: 'extra-value',
+      }),
+    );
+  });
 });

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -6,7 +6,7 @@ import {
   HttpStatus,
   Logger,
 } from '@nestjs/common';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { Response } from 'express';
 import { RequestContext } from '../interfaces/request-context.interface';
 
@@ -40,15 +40,26 @@ export class HttpExceptionFilter implements ExceptionFilter {
       randomUUID();
     const role = request.user?.role ?? 'ANON';
     const userId = request.user?.userId ?? 'anonymous';
-    const errorCode =
+    let errorCode = 'UnhandledException';
+    if (
       typeof exceptionResponse === 'object' &&
       exceptionResponse !== null &&
       'error' in exceptionResponse &&
       typeof (exceptionResponse as { error?: unknown }).error === 'string'
-        ? (exceptionResponse as { error: string }).error
-        : exception instanceof Error
-          ? exception.name
-          : 'UnhandledException';
+    ) {
+      errorCode = (exceptionResponse as { error: string }).error;
+    } else if (exception instanceof Error) {
+      errorCode = exception.name;
+    }
+
+    const extraFields =
+      typeof exceptionResponse === 'object' && exceptionResponse !== null
+        ? Object.fromEntries(
+            Object.entries(exceptionResponse).filter(
+              ([key]) => !['statusCode', 'message'].includes(key),
+            ),
+          )
+        : {};
 
     response.setHeader('x-correlation-id', correlationId);
     this.logger.error(
@@ -69,6 +80,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     response.status(status).json({
       statusCode: status,
       message,
+      ...extraFields,
       path: endpoint,
       timestamp: new Date().toISOString(),
       correlation_id: correlationId,

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -51,6 +51,16 @@ describe('config factories', () => {
     expect(config.outboxDispatchIntervalMs).toBe(1000);
   });
 
+  it('redisConfig should respect custom prefix and positive dispatch interval', () => {
+    process.env.REDIS_KEY_PREFIX = 'custom-prefix';
+    process.env.OUTBOX_DISPATCH_INTERVAL_MS = '2500';
+
+    const config = redisConfig();
+
+    expect(config.keyPrefix).toBe('custom-prefix');
+    expect(config.outboxDispatchIntervalMs).toBe(2500);
+  });
+
   it('aiConfig should map ai flags and defaults', () => {
     process.env.AI_ENABLED = 'true';
     process.env.AI_PROVIDER = 'gemini';
@@ -62,6 +72,20 @@ describe('config factories', () => {
     expect(config.provider).toBe('gemini');
     expect(config.geminiApiKey).toBe('key');
     expect(config.model).toBe('gemini-2.5-flash');
+  });
+
+  it('aiConfig should apply provider and key defaults for missing values', () => {
+    process.env.AI_ENABLED = 'false';
+    delete process.env.AI_PROVIDER;
+    process.env.GEMINI_API_KEY = '';
+    process.env.GEMINI_MODEL = 'gemini-custom';
+
+    const config = aiConfig();
+
+    expect(config.enabled).toBe(false);
+    expect(config.provider).toBe('gemini');
+    expect(config.geminiApiKey).toBeUndefined();
+    expect(config.model).toBe('gemini-custom');
   });
 
   it('webConfig should parse CORS origins and numeric limits', () => {

--- a/src/config/validation.schema.ts
+++ b/src/config/validation.schema.ts
@@ -26,6 +26,10 @@ export const validationSchema = Joi.object({
   OUTBOX_DISPATCH_INTERVAL_MS: Joi.number().integer().min(1).optional(),
   AI_ENABLED: Joi.boolean().default(false),
   AI_PROVIDER: Joi.string().valid('gemini').default('gemini'),
-  GEMINI_API_KEY: Joi.string().allow('').optional(),
+  GEMINI_API_KEY: Joi.when('AI_ENABLED', {
+    is: true,
+    then: Joi.string().trim().min(1).required(),
+    otherwise: Joi.string().allow('').optional(),
+  }),
   GEMINI_MODEL: Joi.string().allow('').optional(),
 });

--- a/src/consultations/consultations.controller.spec.ts
+++ b/src/consultations/consultations.controller.spec.ts
@@ -2,7 +2,10 @@ import { ConsultationsController } from './consultations.controller';
 
 describe('ConsultationsController', () => {
   it('getQueue should return empty items', () => {
-    const controller = new ConsultationsController();
+    const controller = new ConsultationsController({
+      getQueue: jest.fn().mockReturnValue({ items: [] }),
+    } as never);
+
     expect(controller.getQueue()).toEqual({ items: [] });
   });
 });

--- a/src/consultations/consultations.controller.ts
+++ b/src/consultations/consultations.controller.ts
@@ -2,13 +2,16 @@ import { Controller, Get, UseGuards } from '@nestjs/common';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../common/enums/user-role.enum';
 import { DoctorVerifiedGuard } from '../common/guards/doctor-verified.guard';
+import { ConsultationsService } from './consultations.service';
 
 @Controller('consultations')
 export class ConsultationsController {
+  constructor(private readonly consultationsService: ConsultationsService) {}
+
   @Get('queue')
   @Roles(UserRole.DOCTOR)
   @UseGuards(DoctorVerifiedGuard)
   getQueue() {
-    return { items: [] };
+    return this.consultationsService.getQueue();
   }
 }

--- a/src/consultations/consultations.module.ts
+++ b/src/consultations/consultations.module.ts
@@ -3,12 +3,21 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { DoctorVerifiedGuard } from '../common/guards/doctor-verified.guard';
 import { Doctor, DoctorSchema } from '../doctors/schemas/doctor.schema';
 import { ConsultationsController } from './consultations.controller';
+import { ConsultationsService } from './consultations.service';
+import {
+  Consultation,
+  ConsultationSchema,
+} from './schemas/consultation.schema';
 
 @Module({
   imports: [
-    MongooseModule.forFeature([{ name: Doctor.name, schema: DoctorSchema }]),
+    MongooseModule.forFeature([
+      { name: Doctor.name, schema: DoctorSchema },
+      { name: Consultation.name, schema: ConsultationSchema },
+    ]),
   ],
   controllers: [ConsultationsController],
-  providers: [DoctorVerifiedGuard],
+  providers: [DoctorVerifiedGuard, ConsultationsService],
+  exports: [ConsultationsService],
 })
 export class ConsultationsModule {}

--- a/src/consultations/consultations.service.spec.ts
+++ b/src/consultations/consultations.service.spec.ts
@@ -1,0 +1,140 @@
+import { getModelToken } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClientSession, Types } from 'mongoose';
+import { Specialty } from '../common/enums/specialty.enum';
+import { ConsultationsService } from './consultations.service';
+import { Consultation } from './schemas/consultation.schema';
+
+describe('ConsultationsService', () => {
+  let service: ConsultationsService;
+
+  const aggregateExecMock = jest.fn();
+  const consultationModel = {
+    create: jest.fn(),
+    aggregate: jest.fn().mockReturnValue({
+      exec: aggregateExecMock,
+    }),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    aggregateExecMock.mockResolvedValue([]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConsultationsService,
+        {
+          provide: getModelToken(Consultation.name),
+          useValue: consultationModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ConsultationsService>(ConsultationsService);
+  });
+
+  it('creates consultation using string ids without session', async () => {
+    consultationModel.create.mockResolvedValue([]);
+
+    await service.createFromTriage({
+      patientId: new Types.ObjectId().toString(),
+      triageSessionId: new Types.ObjectId().toString(),
+      specialty: Specialty.GENERAL_MEDICINE,
+      priority: 'HIGH',
+    });
+
+    expect(consultationModel.create).toHaveBeenCalledTimes(1);
+    const [payload, options] = consultationModel.create.mock.calls[0] as [
+      Array<{
+        patientId: Types.ObjectId;
+        triageSessionId: Types.ObjectId;
+      }>,
+      unknown,
+    ];
+
+    expect(payload[0].patientId).toBeInstanceOf(Types.ObjectId);
+    expect(payload[0].triageSessionId).toBeInstanceOf(Types.ObjectId);
+    expect(options).toBeUndefined();
+  });
+
+  it('creates consultation using object ids with session', async () => {
+    consultationModel.create.mockResolvedValue([]);
+    const patientId = new Types.ObjectId();
+    const triageSessionId = new Types.ObjectId();
+    const session = { id: 'tx-1' } as unknown as ClientSession;
+
+    await service.createFromTriage(
+      {
+        patientId,
+        triageSessionId,
+        specialty: Specialty.ODONTOLOGY,
+        priority: 'LOW',
+      },
+      session,
+    );
+
+    expect(consultationModel.create).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          patientId,
+          triageSessionId,
+          specialty: Specialty.ODONTOLOGY,
+          priority: 'LOW',
+          status: 'PENDING',
+        }),
+      ],
+      { session },
+    );
+  });
+
+  it('returns paginated queue using clamped defaults', async () => {
+    aggregateExecMock.mockResolvedValue([{ id: 'queue-1' }]);
+
+    const result = await service.getQueue({ limit: 999, page: 0 });
+
+    expect(result).toEqual({ items: [{ id: 'queue-1' }] });
+    expect(consultationModel.aggregate).toHaveBeenCalledTimes(1);
+
+    const [pipeline] = consultationModel.aggregate.mock.calls[0] as [
+      Array<Record<string, unknown>>,
+    ];
+    expect(pipeline[3]).toEqual({ $skip: 0 });
+    expect(pipeline[4]).toEqual({ $limit: 100 });
+  });
+
+  it('calculates skip using provided page and limit', async () => {
+    aggregateExecMock.mockResolvedValue([]);
+
+    await service.getQueue({ limit: 20, page: 3 });
+
+    const [pipeline] = consultationModel.aggregate.mock.calls[0] as [
+      Array<Record<string, unknown>>,
+    ];
+    expect(pipeline[3]).toEqual({ $skip: 40 });
+    expect(pipeline[4]).toEqual({ $limit: 20 });
+  });
+
+  it('uses default pagination values when options are not provided', async () => {
+    aggregateExecMock.mockResolvedValue([]);
+
+    await service.getQueue();
+
+    const [pipeline] = consultationModel.aggregate.mock.calls[0] as [
+      Array<Record<string, unknown>>,
+    ];
+    expect(pipeline[3]).toEqual({ $skip: 0 });
+    expect(pipeline[4]).toEqual({ $limit: 100 });
+  });
+
+  it('clamps limit to minimum value', async () => {
+    aggregateExecMock.mockResolvedValue([]);
+
+    await service.getQueue({ limit: -3, page: 2 });
+
+    const [pipeline] = consultationModel.aggregate.mock.calls[0] as [
+      Array<Record<string, unknown>>,
+    ];
+    expect(pipeline[3]).toEqual({ $skip: 1 });
+    expect(pipeline[4]).toEqual({ $limit: 1 });
+  });
+});

--- a/src/consultations/consultations.service.spec.ts
+++ b/src/consultations/consultations.service.spec.ts
@@ -201,4 +201,68 @@ describe('ConsultationsService', () => {
     expect(result.items).toHaveLength(1);
     expect(result.items[0].priority).toBe('LOW');
   });
+
+  it('uses createdAt as tie-breaker when priorities are equal', async () => {
+    const older = new Date('2026-04-07T00:00:00.000Z');
+    const newer = new Date('2026-04-08T00:00:00.000Z');
+    const firstId = new Types.ObjectId();
+    const secondId = new Types.ObjectId();
+
+    findExecMock.mockResolvedValue([
+      {
+        _id: secondId,
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'LOW',
+        status: 'PENDING',
+        createdAt: newer,
+      },
+      {
+        _id: firstId,
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'LOW',
+        status: 'PENDING',
+        createdAt: older,
+      },
+    ]);
+
+    const result = await service.getQueue({ limit: 10, page: 1 });
+
+    expect(result.items[0].id).toBe(firstId.toString());
+    expect(result.items[1].id).toBe(secondId.toString());
+  });
+
+  it('sends unknown priorities to the end using fallback rank', async () => {
+    const knownId = new Types.ObjectId();
+    const unknownId = new Types.ObjectId();
+
+    findExecMock.mockResolvedValue([
+      {
+        _id: unknownId,
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'UNKNOWN' as unknown as 'LOW',
+        status: 'PENDING',
+        createdAt: null,
+      },
+      {
+        _id: knownId,
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'LOW',
+        status: 'PENDING',
+        createdAt: null,
+      },
+    ]);
+
+    const result = await service.getQueue({ limit: 10, page: 1 });
+
+    expect(result.items[0].id).toBe(knownId.toString());
+    expect(result.items[1].id).toBe(unknownId.toString());
+  });
 });

--- a/src/consultations/consultations.service.spec.ts
+++ b/src/consultations/consultations.service.spec.ts
@@ -8,17 +8,21 @@ import { Consultation } from './schemas/consultation.schema';
 describe('ConsultationsService', () => {
   let service: ConsultationsService;
 
-  const aggregateExecMock = jest.fn();
+  const findExecMock = jest.fn();
+  const findChain = {
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockReturnThis(),
+    exec: findExecMock,
+  };
+
   const consultationModel = {
     create: jest.fn(),
-    aggregate: jest.fn().mockReturnValue({
-      exec: aggregateExecMock,
-    }),
+    find: jest.fn().mockReturnValue(findChain),
   };
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    aggregateExecMock.mockResolvedValue([]);
+    findExecMock.mockResolvedValue([]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -88,53 +92,113 @@ describe('ConsultationsService', () => {
   });
 
   it('returns paginated queue using clamped defaults', async () => {
-    aggregateExecMock.mockResolvedValue([{ id: 'queue-1' }]);
+    const consultationId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    const triageSessionId = new Types.ObjectId();
+    findExecMock.mockResolvedValue([
+      {
+        _id: consultationId,
+        patientId,
+        triageSessionId,
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'MODERATE',
+        status: 'PENDING',
+        createdAt: null,
+      },
+    ]);
 
     const result = await service.getQueue({ limit: 999, page: 0 });
 
-    expect(result).toEqual({ items: [{ id: 'queue-1' }] });
-    expect(consultationModel.aggregate).toHaveBeenCalledTimes(1);
-
-    const [pipeline] = consultationModel.aggregate.mock.calls[0] as [
-      Array<Record<string, unknown>>,
-    ];
-    expect(pipeline[3]).toEqual({ $skip: 0 });
-    expect(pipeline[4]).toEqual({ $limit: 100 });
+    expect(result).toEqual({
+      items: [
+        {
+          id: consultationId.toString(),
+          patientId: patientId.toString(),
+          triageSessionId: triageSessionId.toString(),
+          specialty: Specialty.GENERAL_MEDICINE,
+          priority: 'MODERATE',
+          status: 'PENDING',
+          createdAt: null,
+        },
+      ],
+    });
+    expect(consultationModel.find).toHaveBeenCalledWith({ status: 'PENDING' });
+    expect(findChain.select).toHaveBeenCalledWith(
+      '_id patientId triageSessionId specialty priority status createdAt',
+    );
   });
 
   it('calculates skip using provided page and limit', async () => {
-    aggregateExecMock.mockResolvedValue([]);
+    const baseDate = new Date('2026-04-07T00:00:00.000Z');
+    findExecMock.mockResolvedValue([
+      {
+        _id: new Types.ObjectId(),
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'HIGH',
+        status: 'PENDING',
+        createdAt: new Date(baseDate.getTime() + 1000),
+      },
+      {
+        _id: new Types.ObjectId(),
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'MODERATE',
+        status: 'PENDING',
+        createdAt: new Date(baseDate.getTime() + 2000),
+      },
+      {
+        _id: new Types.ObjectId(),
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'LOW',
+        status: 'PENDING',
+        createdAt: new Date(baseDate.getTime() + 3000),
+      },
+    ]);
 
-    await service.getQueue({ limit: 20, page: 3 });
+    const result = await service.getQueue({ limit: 1, page: 2 });
 
-    const [pipeline] = consultationModel.aggregate.mock.calls[0] as [
-      Array<Record<string, unknown>>,
-    ];
-    expect(pipeline[3]).toEqual({ $skip: 40 });
-    expect(pipeline[4]).toEqual({ $limit: 20 });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].priority).toBe('MODERATE');
   });
 
   it('uses default pagination values when options are not provided', async () => {
-    aggregateExecMock.mockResolvedValue([]);
+    findExecMock.mockResolvedValue([]);
 
-    await service.getQueue();
+    const result = await service.getQueue();
 
-    const [pipeline] = consultationModel.aggregate.mock.calls[0] as [
-      Array<Record<string, unknown>>,
-    ];
-    expect(pipeline[3]).toEqual({ $skip: 0 });
-    expect(pipeline[4]).toEqual({ $limit: 100 });
+    expect(result).toEqual({ items: [] });
   });
 
   it('clamps limit to minimum value', async () => {
-    aggregateExecMock.mockResolvedValue([]);
+    findExecMock.mockResolvedValue([
+      {
+        _id: new Types.ObjectId(),
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'HIGH',
+        status: 'PENDING',
+        createdAt: null,
+      },
+      {
+        _id: new Types.ObjectId(),
+        patientId: new Types.ObjectId(),
+        triageSessionId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        priority: 'LOW',
+        status: 'PENDING',
+        createdAt: null,
+      },
+    ]);
 
-    await service.getQueue({ limit: -3, page: 2 });
+    const result = await service.getQueue({ limit: -3, page: 2 });
 
-    const [pipeline] = consultationModel.aggregate.mock.calls[0] as [
-      Array<Record<string, unknown>>,
-    ];
-    expect(pipeline[3]).toEqual({ $skip: 1 });
-    expect(pipeline[4]).toEqual({ $limit: 1 });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].priority).toBe('LOW');
   });
 });

--- a/src/consultations/consultations.service.ts
+++ b/src/consultations/consultations.service.ts
@@ -40,31 +40,65 @@ export class ConsultationsService {
     );
   }
 
-  async getQueue() {
+  async getQueue(options: { limit?: number; page?: number } = {}) {
+    const limit = Math.min(Math.max(options.limit ?? 100, 1), 100);
+    const page = Math.max(options.page ?? 1, 1);
+    const skip = (page - 1) * limit;
+
     const items = await this.consultationModel
-      .find({ status: 'PENDING' })
-      .lean()
+      .aggregate<
+        Pick<
+          ConsultationDocument,
+          | '_id'
+          | 'patientId'
+          | 'triageSessionId'
+          | 'specialty'
+          | 'priority'
+          | 'status'
+          | 'createdAt'
+        >
+      >([
+        {
+          $match: {
+            status: 'PENDING',
+          },
+        },
+        {
+          $addFields: {
+            priorityRank: {
+              $switch: {
+                branches: [
+                  { case: { $eq: ['$priority', 'HIGH'] }, then: 0 },
+                  { case: { $eq: ['$priority', 'MODERATE'] }, then: 1 },
+                  { case: { $eq: ['$priority', 'LOW'] }, then: 2 },
+                ],
+                default: 3,
+              },
+            },
+          },
+        },
+        {
+          $sort: {
+            priorityRank: 1,
+            createdAt: 1,
+          },
+        },
+        {
+          $skip: skip,
+        },
+        {
+          $limit: limit,
+        },
+        {
+          $project: {
+            priorityRank: 0,
+          },
+        },
+      ])
       .exec();
 
-    const priorityRank: Record<TriagePriority, number> = {
-      HIGH: 0,
-      MODERATE: 1,
-      LOW: 2,
-    };
-
-    const orderedItems = [...items].sort((a, b) => {
-      const byPriority = priorityRank[a.priority] - priorityRank[b.priority];
-      if (byPriority !== 0) {
-        return byPriority;
-      }
-
-      const aCreatedAt = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-      const bCreatedAt = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-      return aCreatedAt - bCreatedAt;
-    });
-
     return {
-      items: orderedItems.map((consultation) => ({
+      items: items.map((consultation) => ({
         id: consultation._id.toString(),
         patientId: consultation.patientId.toString(),
         triageSessionId: consultation.triageSessionId.toString(),

--- a/src/consultations/consultations.service.ts
+++ b/src/consultations/consultations.service.ts
@@ -42,22 +42,15 @@ export class ConsultationsService {
 
   async getQueue(options: { limit?: number; page?: number } = {}) {
     const limit = Math.min(Math.max(options.limit ?? 100, 1), 100);
-    const page = Math.max(options.page ?? 1, 1);
-    const skip = (page - 1) * limit;
-
-    const items = await this.consultationModel
-      .aggregate<
-        Pick<
-          ConsultationDocument,
-          | '_id'
-          | 'patientId'
-          | 'triageSessionId'
-          | 'specialty'
-          | 'priority'
-          | 'status'
-          | 'createdAt'
-        >
-      >([
+      .aggregate<{
+        id: string;
+        patientId: string;
+        triageSessionId: string;
+        specialty: Specialty;
+        priority: TriagePriority;
+        status: string;
+        createdAt: Date | null;
+      }>([
         {
           $match: {
             status: 'PENDING',
@@ -72,7 +65,34 @@ export class ConsultationsService {
                   { case: { $eq: ['$priority', 'MODERATE'] }, then: 1 },
                   { case: { $eq: ['$priority', 'LOW'] }, then: 2 },
                 ],
-                default: 3,
+                default: 99,
+              },
+            },
+          },
+        },
+        {
+          $sort: {
+            priorityRank: 1,
+            createdAt: 1,
+          },
+        },
+        {
+          $project: {
+            _id: 0,
+            id: { $toString: '$_id' },
+            patientId: { $toString: '$patientId' },
+            triageSessionId: { $toString: '$triageSessionId' },
+            specialty: 1,
+            priority: 1,
+            status: 1,
+            createdAt: { $ifNull: ['$createdAt', null] },
+          },
+        },
+      ])
+      .exec();
+
+    return {
+      items,
               },
             },
           },

--- a/src/consultations/consultations.service.ts
+++ b/src/consultations/consultations.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { ClientSession, Model, Types } from 'mongoose';
+import { Specialty } from '../common/enums/specialty.enum';
+import { TriagePriority } from '../triage/schemas/triage-session.schema';
+import {
+  Consultation,
+  ConsultationDocument,
+} from './schemas/consultation.schema';
+
+type CreateConsultationFromTriageInput = {
+  patientId: string | Types.ObjectId;
+  triageSessionId: string | Types.ObjectId;
+  specialty: Specialty;
+  priority: TriagePriority;
+};
+
+@Injectable()
+export class ConsultationsService {
+  constructor(
+    @InjectModel(Consultation.name)
+    private readonly consultationModel: Model<ConsultationDocument>,
+  ) {}
+
+  async createFromTriage(
+    input: CreateConsultationFromTriageInput,
+    session?: ClientSession,
+  ): Promise<void> {
+    await this.consultationModel.create(
+      [
+        {
+          patientId: this.toObjectId(input.patientId),
+          triageSessionId: this.toObjectId(input.triageSessionId),
+          specialty: input.specialty,
+          priority: input.priority,
+          status: 'PENDING',
+        },
+      ],
+      session ? { session } : undefined,
+    );
+  }
+
+  async getQueue() {
+    const items = await this.consultationModel
+      .find({ status: 'PENDING' })
+      .lean()
+      .exec();
+
+    const priorityRank: Record<TriagePriority, number> = {
+      HIGH: 0,
+      MODERATE: 1,
+      LOW: 2,
+    };
+
+    const orderedItems = [...items].sort((a, b) => {
+      const byPriority = priorityRank[a.priority] - priorityRank[b.priority];
+      if (byPriority !== 0) {
+        return byPriority;
+      }
+
+      const aCreatedAt = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bCreatedAt = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return aCreatedAt - bCreatedAt;
+    });
+
+    return {
+      items: orderedItems.map((consultation) => ({
+        id: consultation._id.toString(),
+        patientId: consultation.patientId.toString(),
+        triageSessionId: consultation.triageSessionId.toString(),
+        specialty: consultation.specialty,
+        priority: consultation.priority,
+        status: consultation.status,
+        createdAt: consultation.createdAt ?? null,
+      })),
+    };
+  }
+
+  private toObjectId(value: string | Types.ObjectId): Types.ObjectId {
+    if (value instanceof Types.ObjectId) {
+      return value;
+    }
+
+    return new Types.ObjectId(value);
+  }
+}

--- a/src/consultations/consultations.service.ts
+++ b/src/consultations/consultations.service.ts
@@ -15,6 +15,16 @@ type CreateConsultationFromTriageInput = {
   priority: TriagePriority;
 };
 
+type QueueRow = {
+  _id: Types.ObjectId;
+  patientId: Types.ObjectId;
+  triageSessionId: Types.ObjectId;
+  specialty: Specialty;
+  priority: TriagePriority;
+  status: string;
+  createdAt: Date | null;
+};
+
 @Injectable()
 export class ConsultationsService {
   constructor(
@@ -45,64 +55,55 @@ export class ConsultationsService {
     const page = Math.max(options.page ?? 1, 1);
     const skip = (page - 1) * limit;
 
-    const items = await this.consultationModel
-      .aggregate<{
-        id: string;
-        patientId: string;
-        triageSessionId: string;
-        specialty: Specialty;
-        priority: TriagePriority;
-        status: string;
-        createdAt: Date | null;
-      }>([
-        {
-          $match: {
-            status: 'PENDING',
-          },
-        },
-        {
-          $addFields: {
-            priorityRank: {
-              $switch: {
-                branches: [
-                  { case: { $eq: ['$priority', 'HIGH'] }, then: 0 },
-                  { case: { $eq: ['$priority', 'MODERATE'] }, then: 1 },
-                  { case: { $eq: ['$priority', 'LOW'] }, then: 2 },
-                ],
-                default: 99,
-              },
-            },
-          },
-        },
-        {
-          $sort: {
-            priorityRank: 1,
-            createdAt: 1,
-          },
-        },
-        {
-          $skip: skip,
-        },
-        {
-          $limit: limit,
-        },
-        {
-          $project: {
-            _id: 0,
-            priorityRank: 0,
-            id: { $toString: '$_id' },
-            patientId: { $toString: '$patientId' },
-            triageSessionId: { $toString: '$triageSessionId' },
-            specialty: 1,
-            priority: 1,
-            status: 1,
-            createdAt: { $ifNull: ['$createdAt', null] },
-          },
-        },
-      ])
-      .exec();
+    const pendingConsultations = (await this.consultationModel
+      .find({ status: 'PENDING' })
+      .select(
+        '_id patientId triageSessionId specialty priority status createdAt',
+      )
+      .lean()
+      .exec()) as QueueRow[];
+
+    const sortedPendingConsultations = [...pendingConsultations];
+    sortedPendingConsultations.sort((a, b) => {
+      const priorityRankDifference =
+        this.getPriorityRank(a.priority) - this.getPriorityRank(b.priority);
+
+      if (priorityRankDifference !== 0) {
+        return priorityRankDifference;
+      }
+
+      const createdAtA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const createdAtB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return createdAtA - createdAtB;
+    });
+
+    const queueRows = sortedPendingConsultations.slice(skip, skip + limit);
+
+    const items = queueRows.map((row) => ({
+      id: row._id.toString(),
+      patientId: row.patientId.toString(),
+      triageSessionId: row.triageSessionId.toString(),
+      specialty: row.specialty,
+      priority: row.priority,
+      status: row.status,
+      createdAt: row.createdAt,
+    }));
 
     return { items };
+  }
+
+  private getPriorityRank(priority: TriagePriority): number {
+    if (priority === 'HIGH') {
+      return 0;
+    }
+    if (priority === 'MODERATE') {
+      return 1;
+    }
+    if (priority === 'LOW') {
+      return 2;
+    }
+
+    return 99;
   }
 
   private toObjectId(value: string | Types.ObjectId): Types.ObjectId {

--- a/src/consultations/schemas/consultation.schema.ts
+++ b/src/consultations/schemas/consultation.schema.ts
@@ -1,0 +1,52 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Types } from 'mongoose';
+import { Specialty } from '../../common/enums/specialty.enum';
+import type { TriagePriority } from '../../triage/schemas/triage-session.schema';
+
+export const CONSULTATION_STATUSES = [
+  'PENDING',
+  'IN_ATTENTION',
+  'CLOSED',
+] as const;
+export type ConsultationStatus = (typeof CONSULTATION_STATUSES)[number];
+
+export type ConsultationDocument = HydratedDocument<Consultation>;
+
+@Schema({ timestamps: true })
+export class Consultation {
+  @Prop({ type: Types.ObjectId, ref: 'Patient', required: true, index: true })
+  patientId!: Types.ObjectId;
+
+  @Prop({
+    type: Types.ObjectId,
+    ref: 'TriageSession',
+    required: true,
+    unique: true,
+    index: true,
+  })
+  triageSessionId!: Types.ObjectId;
+
+  @Prop({ required: true, type: String, enum: Specialty })
+  specialty!: Specialty;
+
+  @Prop({ required: true, type: String, enum: ['LOW', 'MODERATE', 'HIGH'] })
+  priority!: TriagePriority;
+
+  @Prop({
+    required: true,
+    type: String,
+    enum: CONSULTATION_STATUSES,
+    default: 'PENDING',
+  })
+  status!: ConsultationStatus;
+
+  @Prop({ type: Types.ObjectId, ref: 'Doctor' })
+  assignedDoctorId?: Types.ObjectId;
+
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export const ConsultationSchema = SchemaFactory.createForClass(Consultation);
+
+ConsultationSchema.index({ status: 1, priority: 1, createdAt: 1 });

--- a/src/dashboard/metrics/in-memory-technical-metrics.store.spec.ts
+++ b/src/dashboard/metrics/in-memory-technical-metrics.store.spec.ts
@@ -18,11 +18,8 @@ describe('InMemoryTechnicalMetricsStore', () => {
 
     for (let index = 1; index <= 1_005; index += 1) {
       await store.record({
-        method: 'GET',
-        path: `/items/${index}`,
         statusCode: index % 10 === 0 ? 500 : 200,
         latencyMs: index,
-        timestamp: new Date().toISOString(),
       });
     }
 

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { getConnectionToken } from '@nestjs/mongoose';
+import { SwaggerModule } from '@nestjs/swagger';
 import type { Connection } from 'mongoose';
 import {
   bootstrap,
@@ -101,6 +102,8 @@ describe('main bootstrap', () => {
   let logSpy: jest.SpyInstance;
   let warnSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;
+  let swaggerCreateSpy: jest.SpyInstance;
+  let swaggerSetupSpy: jest.SpyInstance;
 
   beforeEach(() => {
     logSpy = jest
@@ -112,12 +115,20 @@ describe('main bootstrap', () => {
     errorSpy = jest
       .spyOn(Logger.prototype, 'error')
       .mockImplementation(() => undefined);
+    swaggerCreateSpy = jest
+      .spyOn(SwaggerModule, 'createDocument')
+      .mockReturnValue({} as never);
+    swaggerSetupSpy = jest
+      .spyOn(SwaggerModule, 'setup')
+      .mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     logSpy.mockRestore();
     warnSpy.mockRestore();
     errorSpy.mockRestore();
+    swaggerCreateSpy.mockRestore();
+    swaggerSetupSpy.mockRestore();
     jest.clearAllMocks();
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { getConnectionToken } from '@nestjs/mongoose';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NextFunction, Request, Response } from 'express';
 import { Connection } from 'mongoose';
 import { AppModule } from './app.module';
@@ -129,8 +130,7 @@ export async function bootstrap() {
     exposedHeaders: ['x-correlation-id'],
   });
 
-  app.use((req: Request, res: Response, next: NextFunction) => {
-    void req;
+  app.use((_req: Request, res: Response, next: NextFunction) => {
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'DENY');
     res.setHeader('Referrer-Policy', 'same-origin');
@@ -146,6 +146,23 @@ export async function bootstrap() {
     }),
   );
   app.useGlobalFilters(new HttpExceptionFilter());
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('SaludDeUna API')
+    .setDescription('Documentacion OpenAPI de SaludDeUna Backend')
+    .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+      'bearer',
+    )
+    .build();
+  const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup(`${globalPrefix}/docs`, app, swaggerDocument);
+
   await app.listen(port);
 
   logger.log(`Server started on http://localhost:${port}/${globalPrefix}`);

--- a/src/modules.spec.ts
+++ b/src/modules.spec.ts
@@ -9,6 +9,7 @@ import { DoctorsModule } from './doctors/doctors.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { OutboxModule } from './outbox/outbox.module';
 import { PatientsModule } from './patients/patients.module';
+import { TriageModule } from './triage/triage.module';
 
 describe('Module definitions', () => {
   it('should load feature modules', () => {
@@ -21,6 +22,7 @@ describe('Module definitions', () => {
     expect(NotificationsModule).toBeDefined();
     expect(DashboardModule).toBeDefined();
     expect(ConsultationsModule).toBeDefined();
+    expect(TriageModule).toBeDefined();
     expect(AdminsModule).toBeDefined();
     expect(OutboxModule).toBeDefined();
   });

--- a/src/outbox/domain-events.processor.ts
+++ b/src/outbox/domain-events.processor.ts
@@ -32,7 +32,7 @@ export class DomainEventsProcessor extends WorkerHost {
     if ((job.attemptsMade ?? 0) >= (job.opts.attempts ?? 1)) {
       await this.outboxService.reschedule(
         job.data.outboxEventId,
-        Math.max(job.attemptsMade, 5),
+        job.attemptsMade,
         error.message,
       );
     }

--- a/src/redis/redis-throttler.storage.ts
+++ b/src/redis/redis-throttler.storage.ts
@@ -1,9 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ThrottlerStorage, ThrottlerStorageService } from '@nestjs/throttler';
-import type { ThrottlerStorageRecord } from '@nestjs/throttler/dist/throttler-storage-record.interface';
 import Redis from 'ioredis';
 import { RedisHealthService } from './redis-health.service';
 
+type ThrottlerStorageRecord = {
+  totalHits: number;
+  timeToExpire: number;
+  isBlocked: boolean;
+  timeToBlockExpire: number;
+};
 @Injectable()
 export class RedisThrottlerStorage implements ThrottlerStorage {
   private readonly logger = new Logger(RedisThrottlerStorage.name);

--- a/src/redis/redis-url.util.ts
+++ b/src/redis/redis-url.util.ts
@@ -11,8 +11,8 @@ export function parseRedisUrl(
 ): ParsedRedisOptions {
   const parsedUrl = new URL(redisUrl);
   const port = parsedUrl.port ? Number(parsedUrl.port) : 6379;
-  const db = parsedUrl.pathname
-    ? Number(parsedUrl.pathname.replace('/', ''))
+  const db = /^\/\d+$/.test(parsedUrl.pathname)
+    ? Number(parsedUrl.pathname.slice(1))
     : undefined;
   const tls = parsedUrl.protocol === 'rediss:' ? {} : undefined;
   const baseConnection: ConnectionOptions = {

--- a/src/triage/README.md
+++ b/src/triage/README.md
@@ -1,0 +1,161 @@
+# Triage API Contracts
+
+## Specialty enum (exact values)
+
+- `GENERAL_MEDICINE`
+- `ODONTOLOGY`
+
+Any other value (for example `DENTISTRY`) returns HTTP 400 by global validation.
+
+## Endpoints
+
+### 1) Create session
+
+`POST /v1/triage/sessions`
+
+Request:
+
+```json
+{
+  "specialty": "GENERAL_MEDICINE"
+}
+```
+
+Success `201`:
+
+```json
+{
+  "sessionId": "680f0493bba79f530f7486f1",
+  "specialty": "GENERAL_MEDICINE",
+  "status": "IN_PROGRESS",
+  "questions": [
+    {
+      "questionId": "MG-Q1",
+      "questionText": "Cual es tu sintoma principal?"
+    }
+  ],
+  "totalQuestions": 5,
+  "answeredCount": 0,
+  "remainingQuestions": 5,
+  "progressPercent": 0,
+  "nextQuestionId": "MG-Q1",
+  "isComplete": false
+}
+```
+
+Conflict `409` (resume hint):
+
+```json
+{
+  "statusCode": 409,
+  "errorCode": "TRIAGE_SESSION_IN_PROGRESS",
+  "specialty": "GENERAL_MEDICINE",
+  "existingSessionId": "680f0493bba79f530f7486f1",
+  "status": "IN_PROGRESS",
+  "message": "Ya existe una sesion de triage en progreso para esta especialidad",
+  "path": "/v1/triage/sessions",
+  "timestamp": "2026-04-07T18:20:00.000Z",
+  "correlation_id": "e65fd6f0-966d-4d67-9d0b-f0668f752b17"
+}
+```
+
+### 2) Get active sessions
+
+`GET /v1/triage/sessions/active`
+
+Optional query filter:
+
+`GET /v1/triage/sessions/active?specialty=GENERAL_MEDICINE`
+
+Success `200`:
+
+```json
+{
+  "items": [
+    {
+      "id": "680f0493bba79f530f7486f1",
+      "specialty": "GENERAL_MEDICINE",
+      "status": "IN_PROGRESS",
+      "currentStep": 2,
+      "totalSteps": 5,
+      "currentQuestionId": "MG-Q2",
+      "isComplete": false,
+      "createdAt": "2026-04-07T18:18:00.000Z",
+      "updatedAt": "2026-04-07T18:19:10.000Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+### 3) Save answers (advance flow)
+
+`POST /v1/triage/sessions/{sessionId}/answers`
+
+Request:
+
+```json
+{
+  "answers": [
+    { "questionId": "MG-Q1", "answerValue": "cefalea" },
+    { "questionId": "MG-Q2", "answerValue": "2 dias" }
+  ]
+}
+```
+
+Success `200`:
+
+```json
+{
+  "sessionId": "680f0493bba79f530f7486f1",
+  "answersCount": 2,
+  "isComplete": false,
+  "totalQuestions": 5,
+  "answeredCount": 2,
+  "remainingQuestions": 3,
+  "progressPercent": 40,
+  "nextQuestionId": "MG-Q3"
+}
+```
+
+### 4) Cancel active session
+
+`PATCH /v1/triage/sessions/{sessionId}/cancel`
+
+Success `200`:
+
+```json
+{
+  "sessionId": "680f0493bba79f530f7486f1",
+  "specialty": "GENERAL_MEDICINE",
+  "status": "CANCELED",
+  "canceledAt": "2026-04-07T18:20:00.000Z",
+  "message": "Sesion de triage cancelada correctamente"
+}
+```
+
+### 5) Analyze completed answers
+
+`POST /v1/triage/sessions/{sessionId}/analyze`
+
+Success `200`:
+
+```json
+{
+  "sessionId": "680f0493bba79f530f7486f1",
+  "priority": "MODERATE",
+  "redFlags": [],
+  "message": "Analisis de triage completado. Tu caso fue enviado a la cola medica.",
+  "highPriorityAlert": false
+}
+```
+
+## Session statuses
+
+- `IN_PROGRESS`
+- `COMPLETED`
+- `CANCELED`
+- `EXPIRED`
+- `FAILED`
+
+Database integrity: one unique `IN_PROGRESS` session per `patientId + specialty` (partial unique index).

--- a/src/triage/README.md
+++ b/src/triage/README.md
@@ -43,6 +43,8 @@ Success `201`:
 }
 ```
 
+Nota: si el cliente requiere metadatos completos de preguntas (type, options, min/max/step), usar `GET /v1/triage/sessions/{sessionId}` como fuente oficial.
+
 Conflict `409` (resume hint):
 
 ```json
@@ -88,7 +90,65 @@ Success `200`:
 }
 ```
 
-### 3) Save answers (advance flow)
+### 3) Get session detail (resume/hydrate questionnaire)
+
+`GET /v1/triage/sessions/{sessionId}`
+
+Success `200`:
+
+```json
+{
+  "id": "680f0493bba79f530f7486f1",
+  "sessionId": "680f0493bba79f530f7486f1",
+  "specialty": "GENERAL_MEDICINE",
+  "status": "IN_PROGRESS",
+  "isComplete": false,
+  "currentQuestionId": "MG-Q2",
+  "currentStep": 2,
+  "totalSteps": 5,
+  "totalQuestions": 5,
+  "nextQuestionId": "MG-Q2",
+  "questions": [
+    {
+      "id": "MG-Q1",
+      "questionId": "MG-Q1",
+      "title": "Sintoma principal",
+      "questionText": "Que sintoma principal presentas hoy?",
+      "description": "Selecciona el sintoma que describe mejor tu situacion.",
+      "type": "SINGLE_CHOICE",
+      "options": [
+        {
+          "id": "MG-Q1-HEADACHE",
+          "label": "Dolor de cabeza"
+        }
+      ]
+    },
+    {
+      "id": "MG-Q3",
+      "questionId": "MG-Q3",
+      "title": "Intensidad de sintomas",
+      "questionText": "En una escala de 0 a 10, cual es la intensidad?",
+      "type": "NUMERIC_SCALE",
+      "minValue": 0,
+      "maxValue": 10,
+      "step": 1
+    }
+  ],
+  "createdAt": "2026-04-07T18:18:00.000Z",
+  "updatedAt": "2026-04-07T18:19:10.000Z"
+}
+```
+
+Not found `404` (sesion inexistente o sin ownership):
+
+```json
+{
+  "statusCode": 404,
+  "message": "Sesion de triage no encontrada"
+}
+```
+
+### 4) Save answers (advance flow)
 
 `POST /v1/triage/sessions/{sessionId}/answers`
 
@@ -118,7 +178,7 @@ Success `200`:
 }
 ```
 
-### 4) Cancel active session
+### 5) Cancel active session
 
 `PATCH /v1/triage/sessions/{sessionId}/cancel`
 
@@ -134,7 +194,7 @@ Success `200`:
 }
 ```
 
-### 5) Analyze completed answers
+### 6) Analyze completed answers
 
 `POST /v1/triage/sessions/{sessionId}/analyze`
 
@@ -149,6 +209,41 @@ Success `200`:
   "highPriorityAlert": false
 }
 ```
+
+Service unavailable `503` (error tecnico estable):
+
+```json
+{
+  "statusCode": 503,
+  "errorCode": "TRIAGE_ANALYSIS_DEPENDENCY_UNAVAILABLE",
+  "specialty": "GENERAL_MEDICINE",
+  "sessionId": "680f0493bba79f530f7486f1",
+  "message": "No fue posible completar el analisis de triage en este momento"
+}
+```
+
+Codigos tecnicos de analisis:
+
+- `TRIAGE_ANALYSIS_DEPENDENCY_UNAVAILABLE`: dependencia externa de IA no disponible en analisis de Medicina General.
+- `TRIAGE_ANALYSIS_RULESET_MISSING`: no existe ruleset de preguntas para la especialidad solicitada.
+
+Resiliencia en Medicina General:
+
+- Retry interno con backoff para errores transitorios del proveedor IA.
+- Fallback a priorizacion por reglas si el error transitorio persiste tras reintentos.
+- Si el fallo no es transitorio, la sesion pasa a `FAILED` y retorna `503`.
+
+Campos adicionales para frontend en `200` de analyze:
+
+- `analysisMode`: `AI_ASSISTED` o `RULE_BASED`.
+- `noticeCode` opcional:
+  - `IA_TEMPORARILY_UNAVAILABLE_RULE_BASED_FALLBACK`
+  - `IA_NOT_IMPLEMENTED_RULE_BASED_FALLBACK`
+
+Recomendacion UI:
+
+- Si `analysisMode=RULE_BASED`, mostrar banner informativo no bloqueante:
+  - "Tu analisis fue realizado con reglas clinicas. Puede variar cuando la IA este disponible."
 
 ## Session statuses
 

--- a/src/triage/dto/create-triage-session.dto.ts
+++ b/src/triage/dto/create-triage-session.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { Specialty } from '../../common/enums/specialty.enum';
+
+export class CreateTriageSessionDto {
+  @IsEnum(Specialty)
+  specialty!: Specialty;
+}

--- a/src/triage/dto/get-active-triage-sessions.dto.ts
+++ b/src/triage/dto/get-active-triage-sessions.dto.ts
@@ -1,0 +1,8 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { Specialty } from '../../common/enums/specialty.enum';
+
+export class GetActiveTriageSessionsDto {
+  @IsOptional()
+  @IsEnum(Specialty)
+  specialty?: Specialty;
+}

--- a/src/triage/dto/save-triage-answers.dto.ts
+++ b/src/triage/dto/save-triage-answers.dto.ts
@@ -1,0 +1,11 @@
+import { Type } from 'class-transformer';
+import { ArrayMinSize, IsArray, ValidateNested } from 'class-validator';
+import { TriageAnswerInputDto } from './triage-answer-input.dto';
+
+export class SaveTriageAnswersDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => TriageAnswerInputDto)
+  answers!: TriageAnswerInputDto[];
+}

--- a/src/triage/dto/triage-answer-input.dto.ts
+++ b/src/triage/dto/triage-answer-input.dto.ts
@@ -1,9 +1,52 @@
-import { IsDefined, IsString } from 'class-validator';
+import {
+  IsDefined,
+  IsString,
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+
+function IsAllowedAnswerValue(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isAllowedAnswerValue',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          if (typeof value === 'boolean') {
+            return true;
+          }
+
+          if (typeof value === 'number') {
+            return Number.isFinite(value);
+          }
+
+          if (Array.isArray(value)) {
+            return (
+              value.length > 0 &&
+              value.every(
+                (item) => typeof item === 'string' && item.trim().length > 0,
+              )
+            );
+          }
+
+          return false;
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a boolean, a finite number, or a non-empty array of non-empty strings`;
+        },
+      },
+    });
+  };
+}
 
 export class TriageAnswerInputDto {
   @IsString()
   questionId!: string;
 
   @IsDefined()
-  answerValue!: unknown;
+  @IsAllowedAnswerValue()
+  answerValue!: boolean | number | string[];
 }

--- a/src/triage/dto/triage-answer-input.dto.ts
+++ b/src/triage/dto/triage-answer-input.dto.ts
@@ -15,6 +15,10 @@ function IsAllowedAnswerValue(validationOptions?: ValidationOptions) {
       options: validationOptions,
       validator: {
         validate(value: unknown) {
+          if (typeof value === 'string') {
+            return value.trim().length > 0;
+          }
+
           if (typeof value === 'boolean') {
             return true;
           }
@@ -35,7 +39,7 @@ function IsAllowedAnswerValue(validationOptions?: ValidationOptions) {
           return false;
         },
         defaultMessage(args: ValidationArguments) {
-          return `${args.property} must be a boolean, a finite number, or a non-empty array of non-empty strings`;
+          return `${args.property} must be a non-empty string, a boolean, a finite number, or a non-empty array of non-empty strings`;
         },
       },
     });
@@ -48,5 +52,5 @@ export class TriageAnswerInputDto {
 
   @IsDefined()
   @IsAllowedAnswerValue()
-  answerValue!: boolean | number | string[];
+  answerValue!: string | boolean | number | string[];
 }

--- a/src/triage/dto/triage-answer-input.dto.ts
+++ b/src/triage/dto/triage-answer-input.dto.ts
@@ -1,0 +1,9 @@
+import { IsDefined, IsString } from 'class-validator';
+
+export class TriageAnswerInputDto {
+  @IsString()
+  questionId!: string;
+
+  @IsDefined()
+  answerValue!: unknown;
+}

--- a/src/triage/engines/red-flags.engine.ts
+++ b/src/triage/engines/red-flags.engine.ts
@@ -1,0 +1,196 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Specialty } from '../../common/enums/specialty.enum';
+import {
+  RedFlag,
+  TriageAnswer,
+  TriageRedFlagSeverity,
+} from '../schemas/triage-session.schema';
+
+type RuleGroup = {
+  anyOf: string[];
+};
+
+type MgRule = {
+  code: string;
+  severity: TriageRedFlagSeverity;
+  evidence: string;
+  questionScope?: string[];
+  allOf: RuleGroup[];
+};
+
+type MgCatalog = {
+  version: string;
+  specialty: Specialty;
+  rules: MgRule[];
+};
+
+const CATALOG_CANDIDATE_PATHS = [
+  resolve(__dirname, '../rules/red-flags-mg.json'),
+  resolve(process.cwd(), 'src/triage/rules/red-flags-mg.json'),
+];
+
+function loadMgCatalog(): MgCatalog {
+  const catalogPath = CATALOG_CANDIDATE_PATHS.find((candidatePath) =>
+    existsSync(candidatePath),
+  );
+
+  if (!catalogPath) {
+    throw new Error(
+      'No se encontro el catalogo de red flags de Medicina General',
+    );
+  }
+
+  const catalogRaw = readFileSync(catalogPath, 'utf-8');
+  return JSON.parse(catalogRaw) as MgCatalog;
+}
+
+function normalizeValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .trim();
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'si' : 'no';
+  }
+
+  return '';
+}
+
+function evaluateCatalogRule(rule: MgRule, answers: TriageAnswer[]): boolean {
+  const scopedAnswers =
+    rule.questionScope && rule.questionScope.length > 0
+      ? answers.filter((answer) =>
+          rule.questionScope!.includes(answer.questionId),
+        )
+      : answers;
+
+  const normalizedValues = scopedAnswers
+    .map((answer) => normalizeValue(answer.answerValue))
+    .filter((value) => value.length > 0);
+
+  if (normalizedValues.length === 0) {
+    return false;
+  }
+
+  return rule.allOf.every((group) =>
+    group.anyOf.some((pattern) => {
+      const regex = new RegExp(pattern, 'iu');
+      return normalizedValues.some((value) => regex.test(value));
+    }),
+  );
+}
+
+export class RedFlagsEngine {
+  private static readonly mgCatalog = loadMgCatalog();
+
+  static evaluate(answers: TriageAnswer[], specialty: Specialty): RedFlag[] {
+    if (specialty === Specialty.GENERAL_MEDICINE) {
+      const matches = this.mgCatalog.rules
+        .filter((rule) => evaluateCatalogRule(rule, answers))
+        .map<RedFlag>((rule) => ({
+          code: rule.code,
+          specialty,
+          severity: rule.severity,
+          evidence: rule.evidence,
+        }));
+
+      return this.deduplicateByCode(matches);
+    }
+
+    if (specialty === Specialty.ODONTOLOGY) {
+      return this.deduplicateByCode(this.evaluateOdontology(answers));
+    }
+
+    return [];
+  }
+
+  private static evaluateOdontology(answers: TriageAnswer[]): RedFlag[] {
+    const redFlags: RedFlag[] = [];
+
+    if (this.isAffirmative(this.getAnswerValue(answers, 'OD-Q4'))) {
+      redFlags.push({
+        code: 'RF-OD-001',
+        specialty: Specialty.ODONTOLOGY,
+        severity: 'WARNING',
+        evidence: 'Paciente reporta inflamacion facial o sangrado',
+      });
+    }
+
+    const intensity = this.toNumber(this.getAnswerValue(answers, 'OD-Q3'));
+    if (intensity >= 8) {
+      redFlags.push({
+        code: 'RF-OD-002',
+        specialty: Specialty.ODONTOLOGY,
+        severity: 'WARNING',
+        evidence: `Dolor dental severo reportado: ${intensity}/10`,
+      });
+    }
+
+    if (this.isAffirmative(this.getAnswerValue(answers, 'OD-Q5'))) {
+      redFlags.push({
+        code: 'RF-OD-003',
+        specialty: Specialty.ODONTOLOGY,
+        severity: 'INFO',
+        evidence: 'Paciente reporta sensibilidad termica dental',
+      });
+    }
+
+    return redFlags;
+  }
+
+  private static getAnswerValue(
+    answers: TriageAnswer[],
+    questionId: string,
+  ): unknown {
+    return answers.find((answer) => answer.questionId === questionId)
+      ?.answerValue;
+  }
+
+  private static isAffirmative(value: unknown): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (typeof value !== 'string') {
+      return false;
+    }
+
+    const normalized = value.trim().toLowerCase();
+    return ['si', 'sí', 'yes', 'true', '1'].includes(normalized);
+  }
+
+  private static toNumber(value: unknown): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    return 0;
+  }
+
+  private static deduplicateByCode(flags: RedFlag[]): RedFlag[] {
+    const seen = new Set<string>();
+    return flags.filter((flag) => {
+      if (seen.has(flag.code)) {
+        return false;
+      }
+      seen.add(flag.code);
+      return true;
+    });
+  }
+}

--- a/src/triage/questions/triage-questions.repository.spec.ts
+++ b/src/triage/questions/triage-questions.repository.spec.ts
@@ -1,0 +1,52 @@
+import { Specialty } from '../../common/enums/specialty.enum';
+import { TriageQuestionsRepository } from './triage-questions.repository';
+
+describe('TriageQuestionsRepository', () => {
+  let repository: TriageQuestionsRepository;
+
+  beforeEach(() => {
+    repository = new TriageQuestionsRepository();
+  });
+
+  it('returns cloned questions for the requested specialty', () => {
+    const questions = repository.getQuestionsBySpecialty(
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(questions.length).toBeGreaterThan(0);
+    const firstQuestionId = questions[0].questionId;
+
+    questions[0].questionText = 'mutated';
+    const secondRead = repository.getQuestionsBySpecialty(
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(secondRead[0].questionId).toBe(firstQuestionId);
+    expect(secondRead[0].questionText).not.toBe('mutated');
+  });
+
+  it('finds a question by id and returns undefined when missing', () => {
+    expect(
+      repository.getQuestionById(Specialty.ODONTOLOGY, 'OD-Q2')?.questionText,
+    ).toBeDefined();
+
+    expect(
+      repository.getQuestionById(Specialty.ODONTOLOGY, 'OD-UNKNOWN'),
+    ).toBeUndefined();
+  });
+
+  it('validates question ids by specialty', () => {
+    expect(
+      repository.isQuestionValid(Specialty.GENERAL_MEDICINE, 'MG-Q3'),
+    ).toBe(true);
+    expect(
+      repository.isQuestionValid(Specialty.GENERAL_MEDICINE, 'OD-Q3'),
+    ).toBe(false);
+  });
+
+  it('returns required question ids preserving catalog order', () => {
+    const ids = repository.getRequiredQuestionIds(Specialty.ODONTOLOGY);
+
+    expect(ids).toEqual(['OD-Q1', 'OD-Q2', 'OD-Q3', 'OD-Q4', 'OD-Q5']);
+  });
+});

--- a/src/triage/questions/triage-questions.repository.ts
+++ b/src/triage/questions/triage-questions.repository.ts
@@ -1,9 +1,31 @@
 import { Injectable } from '@nestjs/common';
 import { Specialty } from '../../common/enums/specialty.enum';
 
+export const TRIAGE_QUESTION_TYPES = [
+  'SINGLE_CHOICE',
+  'MULTI_CHOICE',
+  'NUMERIC_SCALE',
+] as const;
+
+export type TriageQuestionType = (typeof TRIAGE_QUESTION_TYPES)[number];
+
+export type TriageQuestionOption = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
 export type TriageQuestion = {
+  id: string;
   questionId: string;
+  title: string;
   questionText: string;
+  description?: string;
+  type: TriageQuestionType;
+  options?: TriageQuestionOption[];
+  minValue?: number;
+  maxValue?: number;
+  step?: number;
 };
 
 @Injectable()
@@ -11,62 +33,170 @@ export class TriageQuestionsRepository {
   private readonly catalog: Record<Specialty, readonly TriageQuestion[]> = {
     [Specialty.GENERAL_MEDICINE]: [
       {
+        id: 'MG-Q1',
         questionId: 'MG-Q1',
+        title: 'Sintoma principal',
         questionText: 'Que sintoma principal presentas hoy?',
+        description: 'Selecciona el sintoma que describe mejor tu situacion.',
+        type: 'SINGLE_CHOICE',
+        options: [
+          {
+            id: 'MG-Q1-HEADACHE',
+            label: 'Dolor de cabeza',
+          },
+          {
+            id: 'MG-Q1-FEVER',
+            label: 'Fiebre',
+          },
+          {
+            id: 'MG-Q1-COUGH',
+            label: 'Tos',
+          },
+          {
+            id: 'MG-Q1-CHEST_PAIN',
+            label: 'Dolor en el pecho',
+            description: 'Si es intenso o repentino, requiere atencion pronta.',
+          },
+          {
+            id: 'MG-Q1-OTHER',
+            label: 'Otro',
+          },
+        ],
       },
       {
+        id: 'MG-Q2',
         questionId: 'MG-Q2',
+        title: 'Tiempo de evolucion',
         questionText: 'Desde cuando presentas el sintoma principal?',
+        type: 'SINGLE_CHOICE',
+        options: [
+          { id: 'MG-Q2-LESS_24H', label: 'Menos de 24 horas' },
+          { id: 'MG-Q2-1_3_DAYS', label: 'Entre 1 y 3 dias' },
+          { id: 'MG-Q2-4_7_DAYS', label: 'Entre 4 y 7 dias' },
+          { id: 'MG-Q2-MORE_WEEK', label: 'Mas de una semana' },
+        ],
       },
       {
+        id: 'MG-Q3',
         questionId: 'MG-Q3',
+        title: 'Intensidad de sintomas',
         questionText: 'En una escala de 0 a 10, cual es la intensidad?',
+        description: '0 es sin molestia y 10 es la maxima intensidad.',
+        type: 'NUMERIC_SCALE',
+        minValue: 0,
+        maxValue: 10,
+        step: 1,
       },
       {
+        id: 'MG-Q4',
         questionId: 'MG-Q4',
+        title: 'Fiebre o escalofrios',
         questionText: 'Presentas fiebre o escalofrios?',
+        type: 'SINGLE_CHOICE',
+        options: [
+          { id: 'MG-Q4-YES', label: 'Si' },
+          { id: 'MG-Q4-NO', label: 'No' },
+        ],
       },
       {
+        id: 'MG-Q5',
         questionId: 'MG-Q5',
+        title: 'Signos de alarma respiratorios',
         questionText: 'Tienes dificultad para respirar o dolor en el pecho?',
+        type: 'MULTI_CHOICE',
+        options: [
+          {
+            id: 'MG-Q5-DYSPNEA',
+            label: 'Dificultad para respirar',
+          },
+          {
+            id: 'MG-Q5-CHEST_PAIN',
+            label: 'Dolor en el pecho',
+          },
+          {
+            id: 'MG-Q5-NONE',
+            label: 'Ninguno',
+          },
+        ],
       },
     ],
     [Specialty.ODONTOLOGY]: [
       {
+        id: 'OD-Q1',
         questionId: 'OD-Q1',
+        title: 'Zona de molestia dental',
         questionText: 'Donde sientes la molestia dental principal?',
+        type: 'SINGLE_CHOICE',
+        options: [
+          { id: 'OD-Q1-UPPER', label: 'Parte superior' },
+          { id: 'OD-Q1-LOWER', label: 'Parte inferior' },
+          { id: 'OD-Q1-JAW', label: 'Mandibula o encia' },
+          { id: 'OD-Q1-GENERAL', label: 'Toda la boca' },
+        ],
       },
       {
+        id: 'OD-Q2',
         questionId: 'OD-Q2',
+        title: 'Inicio del dolor',
         questionText: 'Desde cuando inicio el dolor dental?',
+        type: 'SINGLE_CHOICE',
+        options: [
+          { id: 'OD-Q2-LESS_24H', label: 'Menos de 24 horas' },
+          { id: 'OD-Q2-1_3_DAYS', label: 'Entre 1 y 3 dias' },
+          { id: 'OD-Q2-4_7_DAYS', label: 'Entre 4 y 7 dias' },
+          { id: 'OD-Q2-MORE_WEEK', label: 'Mas de una semana' },
+        ],
       },
       {
+        id: 'OD-Q3',
         questionId: 'OD-Q3',
+        title: 'Intensidad del dolor dental',
         questionText:
           'En una escala de 0 a 10, cual es la intensidad del dolor?',
+        type: 'NUMERIC_SCALE',
+        minValue: 0,
+        maxValue: 10,
+        step: 1,
       },
       {
+        id: 'OD-Q4',
         questionId: 'OD-Q4',
+        title: 'Signos inflamatorios',
         questionText: 'Presentas inflamacion facial o sangrado?',
+        type: 'MULTI_CHOICE',
+        options: [
+          { id: 'OD-Q4-INFLAMMATION', label: 'Inflamacion facial' },
+          { id: 'OD-Q4-BLEEDING', label: 'Sangrado' },
+          { id: 'OD-Q4-NONE', label: 'Ninguno' },
+        ],
       },
       {
+        id: 'OD-Q5',
         questionId: 'OD-Q5',
+        title: 'Desencadenantes termicos',
         questionText: 'El dolor empeora al comer frio o caliente?',
+        type: 'SINGLE_CHOICE',
+        options: [
+          { id: 'OD-Q5-YES', label: 'Si' },
+          { id: 'OD-Q5-NO', label: 'No' },
+        ],
       },
     ],
   };
 
   getQuestionsBySpecialty(specialty: Specialty): TriageQuestion[] {
-    return this.catalog[specialty].map((question) => ({ ...question }));
+    return this.catalog[specialty].map((question) => this.cloneQuestion(question));
   }
 
   getQuestionById(
     specialty: Specialty,
     questionId: string,
   ): TriageQuestion | undefined {
-    return this.catalog[specialty].find(
-      (question) => question.questionId === questionId,
+    const question = this.catalog[specialty].find(
+      (item) => item.questionId === questionId,
     );
+
+    return question ? this.cloneQuestion(question) : undefined;
   }
 
   isQuestionValid(specialty: Specialty, questionId: string): boolean {
@@ -75,5 +205,12 @@ export class TriageQuestionsRepository {
 
   getRequiredQuestionIds(specialty: Specialty): string[] {
     return this.catalog[specialty].map((question) => question.questionId);
+  }
+
+  private cloneQuestion(question: TriageQuestion): TriageQuestion {
+    return {
+      ...question,
+      options: question.options?.map((option) => ({ ...option })),
+    };
   }
 }

--- a/src/triage/questions/triage-questions.repository.ts
+++ b/src/triage/questions/triage-questions.repository.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { Specialty } from '../../common/enums/specialty.enum';
+
+export type TriageQuestion = {
+  questionId: string;
+  questionText: string;
+};
+
+@Injectable()
+export class TriageQuestionsRepository {
+  private readonly catalog: Record<Specialty, readonly TriageQuestion[]> = {
+    [Specialty.GENERAL_MEDICINE]: [
+      {
+        questionId: 'MG-Q1',
+        questionText: 'Que sintoma principal presentas hoy?',
+      },
+      {
+        questionId: 'MG-Q2',
+        questionText: 'Desde cuando presentas el sintoma principal?',
+      },
+      {
+        questionId: 'MG-Q3',
+        questionText: 'En una escala de 0 a 10, cual es la intensidad?',
+      },
+      {
+        questionId: 'MG-Q4',
+        questionText: 'Presentas fiebre o escalofrios?',
+      },
+      {
+        questionId: 'MG-Q5',
+        questionText: 'Tienes dificultad para respirar o dolor en el pecho?',
+      },
+    ],
+    [Specialty.ODONTOLOGY]: [
+      {
+        questionId: 'OD-Q1',
+        questionText: 'Donde sientes la molestia dental principal?',
+      },
+      {
+        questionId: 'OD-Q2',
+        questionText: 'Desde cuando inicio el dolor dental?',
+      },
+      {
+        questionId: 'OD-Q3',
+        questionText:
+          'En una escala de 0 a 10, cual es la intensidad del dolor?',
+      },
+      {
+        questionId: 'OD-Q4',
+        questionText: 'Presentas inflamacion facial o sangrado?',
+      },
+      {
+        questionId: 'OD-Q5',
+        questionText: 'El dolor empeora al comer frio o caliente?',
+      },
+    ],
+  };
+
+  getQuestionsBySpecialty(specialty: Specialty): TriageQuestion[] {
+    return this.catalog[specialty].map((question) => ({ ...question }));
+  }
+
+  getQuestionById(
+    specialty: Specialty,
+    questionId: string,
+  ): TriageQuestion | undefined {
+    return this.catalog[specialty].find(
+      (question) => question.questionId === questionId,
+    );
+  }
+
+  isQuestionValid(specialty: Specialty, questionId: string): boolean {
+    return Boolean(this.getQuestionById(specialty, questionId));
+  }
+
+  getRequiredQuestionIds(specialty: Specialty): string[] {
+    return this.catalog[specialty].map((question) => question.questionId);
+  }
+}

--- a/src/triage/rules/guardrail-rules.json
+++ b/src/triage/rules/guardrail-rules.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0.0",
+  "categories": [
+    {
+      "id": "diagnosis",
+      "label": "Lenguaje de diagnostico",
+      "patterns": [
+        "diagnostico\\s+de",
+        "padece\\s+de",
+        "tiene\\s+(una|un)\\s+[a-záéíóúñ]+",
+        "presenta\\s+cuadro\\s+de",
+        "es\\s+compatible\\s+con"
+      ]
+    },
+    {
+      "id": "prescription",
+      "label": "Lenguaje de prescripcion",
+      "patterns": [
+        "tomar\\s+[a-záéíóúñ]+",
+        "administrar",
+        "recetar",
+        "iniciar\\s+tratamiento",
+        "dosis\\s+de"
+      ]
+    },
+    {
+      "id": "clinical-assertion",
+      "label": "Afirmacion clinica",
+      "patterns": [
+        "es\\s+[a-záéíóúñ]+",
+        "sufre\\s+de",
+        "corresponde\\s+a",
+        "confirmamos\\s+que"
+      ]
+    }
+  ]
+}

--- a/src/triage/rules/red-flags-mg.json
+++ b/src/triage/rules/red-flags-mg.json
@@ -1,0 +1,105 @@
+{
+  "version": "1.0.0",
+  "specialty": "GENERAL_MEDICINE",
+  "rules": [
+    {
+      "code": "RF-MG-001",
+      "severity": "CRITICAL",
+      "evidence": "Combinacion de dolor toracico y dificultad respiratoria reportada",
+      "questionScope": ["MG-Q1", "MG-Q5"],
+      "allOf": [
+        {
+          "anyOf": [
+            "dolor\\s+torac",
+            "opresion\\s+en\\s+el\\s+pecho",
+            "dolor\\s+en\\s+el\\s+pecho"
+          ]
+        },
+        {
+          "anyOf": [
+            "dificultad\\s+para\\s+respirar",
+            "disnea",
+            "falta\\s+de\\s+aire"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "RF-MG-002",
+      "severity": "CRITICAL",
+      "evidence": "Perdida de consciencia o sincope reportado",
+      "questionScope": ["MG-Q1", "MG-Q2", "MG-Q5"],
+      "allOf": [
+        {
+          "anyOf": [
+            "perdida\\s+de\\s+consciencia",
+            "perdio\\s+la\\s+consciencia",
+            "sincope",
+            "desmayo"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "RF-MG-003",
+      "severity": "CRITICAL",
+      "evidence": "Fiebre alta con rigidez de nuca reportada",
+      "questionScope": ["MG-Q1", "MG-Q4"],
+      "allOf": [
+        {
+          "anyOf": [
+            "fiebre\\s*(de|>|mayor\\s+de)?\\s*(39|40|41|42)",
+            "39\\s*\\u00b0?c",
+            "40\\s*\\u00b0?c",
+            "fiebre\\s+alta"
+          ]
+        },
+        {
+          "anyOf": [
+            "rigidez\\s+de\\s+nuca",
+            "nuca\\s+rigida",
+            "dolor\\s+de\\s+nuca"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "RF-MG-004",
+      "severity": "CRITICAL",
+      "evidence": "Dolor abdominal intenso de inicio subito reportado",
+      "questionScope": ["MG-Q1", "MG-Q2", "MG-Q3"],
+      "allOf": [
+        {
+          "anyOf": [
+            "dolor\\s+abdominal\\s+intenso",
+            "dolor\\s+abdominal\\s+severo"
+          ]
+        },
+        {
+          "anyOf": [
+            "inicio\\s+subito",
+            "aparecio\\s+de\\s+repente",
+            "comenzo\\s+de\\s+repente"
+          ]
+        }
+      ]
+    },
+    {
+      "code": "RF-MG-005",
+      "severity": "WARNING",
+      "evidence": "Alteraciones visuales repentinas reportadas",
+      "questionScope": ["MG-Q1", "MG-Q2"],
+      "allOf": [
+        {
+          "anyOf": [
+            "vision\\s+borrosa",
+            "perdida\\s+de\\s+vision",
+            "destellos",
+            "alteraciones\\s+visuales",
+            "no\\s+veo\\s+bien"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/triage/schemas/triage-session.schema.spec.ts
+++ b/src/triage/schemas/triage-session.schema.spec.ts
@@ -64,12 +64,19 @@ describe('TriageSessionSchema', () => {
     expect(error?.errors['analysis.redFlags.0.specialty']).toBeDefined();
   });
 
-  it('should define a compound index on patientId + status', () => {
+  it('should define indexes for query and active-session uniqueness', () => {
     const indexes = TriageSessionSchema.indexes();
 
     expect(indexes).toEqual(
       expect.arrayContaining([
         expect.arrayContaining([{ patientId: 1, status: 1 }]),
+        expect.arrayContaining([
+          { patientId: 1, specialty: 1 },
+          expect.objectContaining({
+            unique: true,
+            partialFilterExpression: { status: 'IN_PROGRESS' },
+          }),
+        ]),
       ]),
     );
   });

--- a/src/triage/schemas/triage-session.schema.spec.ts
+++ b/src/triage/schemas/triage-session.schema.spec.ts
@@ -1,0 +1,76 @@
+import mongoose, { model, Types } from 'mongoose';
+import { Specialty } from '../../common/enums/specialty.enum';
+import { TriageSession, TriageSessionSchema } from './triage-session.schema';
+
+describe('TriageSessionSchema', () => {
+  const modelName = 'TriageSessionSchemaSpec';
+  const TriageSessionModel = model<TriageSession>(
+    modelName,
+    TriageSessionSchema,
+  );
+
+  afterAll(() => {
+    mongoose.deleteModel(modelName);
+  });
+
+  it('should set IN_PROGRESS as default status', () => {
+    const doc = new TriageSessionModel({
+      patientId: new Types.ObjectId(),
+      specialty: Specialty.GENERAL_MEDICINE,
+    });
+
+    expect(doc.status).toBe('IN_PROGRESS');
+  });
+
+  it('should enforce enum validation for status', () => {
+    const doc = new TriageSessionModel({
+      patientId: new Types.ObjectId(),
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'INVALID_STATUS',
+    });
+
+    const error = doc.validateSync();
+
+    expect(error).toBeDefined();
+    expect(error?.errors.status).toBeDefined();
+    expect((error?.errors.status as Error).message).toContain(
+      'not a valid enum value for path `status`',
+    );
+  });
+
+  it('should enforce enum validation for analysis priority and red flag specialty', () => {
+    const doc = new TriageSessionModel({
+      patientId: new Types.ObjectId(),
+      specialty: Specialty.GENERAL_MEDICINE,
+      analysis: {
+        priority: 'URGENT',
+        redFlags: [
+          {
+            code: 'RF-MG-001',
+            specialty: 'DENTISTRY',
+            severity: 'CRITICAL',
+            evidence: 'test',
+          },
+        ],
+        analysisDurationMs: 20,
+        guardrailApplied: false,
+      },
+    });
+
+    const error = doc.validateSync();
+
+    expect(error).toBeDefined();
+    expect(error?.errors['analysis.priority']).toBeDefined();
+    expect(error?.errors['analysis.redFlags.0.specialty']).toBeDefined();
+  });
+
+  it('should define a compound index on patientId + status', () => {
+    const indexes = TriageSessionSchema.indexes();
+
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([{ patientId: 1, status: 1 }]),
+      ]),
+    );
+  });
+});

--- a/src/triage/schemas/triage-session.schema.ts
+++ b/src/triage/schemas/triage-session.schema.ts
@@ -1,0 +1,111 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, SchemaTypes, Types } from 'mongoose';
+import { Specialty } from '../../common/enums/specialty.enum';
+
+export const TRIAGE_SESSION_STATUSES = [
+  'IN_PROGRESS',
+  'COMPLETED',
+  'FAILED',
+] as const;
+
+export type TriageSessionStatus = (typeof TRIAGE_SESSION_STATUSES)[number];
+
+export const TRIAGE_PRIORITIES = ['LOW', 'MODERATE', 'HIGH'] as const;
+export type TriagePriority = (typeof TRIAGE_PRIORITIES)[number];
+
+export const TRIAGE_RED_FLAG_SEVERITIES = [
+  'CRITICAL',
+  'WARNING',
+  'INFO',
+] as const;
+export type TriageRedFlagSeverity = (typeof TRIAGE_RED_FLAG_SEVERITIES)[number];
+
+@Schema({ _id: false })
+export class TriageAnswer {
+  @Prop({ required: true, trim: true })
+  questionId!: string;
+
+  @Prop({ required: true, trim: true })
+  questionText!: string;
+
+  @Prop({ required: true, type: SchemaTypes.Mixed })
+  answerValue!: unknown;
+
+  @Prop({ required: true, type: Date })
+  answeredAt!: Date;
+}
+
+export const TriageAnswerSchema = SchemaFactory.createForClass(TriageAnswer);
+
+@Schema({ _id: false })
+export class RedFlag {
+  @Prop({ required: true, trim: true })
+  code!: string;
+
+  @Prop({ required: true, type: String, enum: Specialty })
+  specialty!: Specialty;
+
+  @Prop({ required: true, type: String, enum: TRIAGE_RED_FLAG_SEVERITIES })
+  severity!: TriageRedFlagSeverity;
+
+  @Prop({ required: true, trim: true })
+  evidence!: string;
+}
+
+export const RedFlagSchema = SchemaFactory.createForClass(RedFlag);
+
+@Schema({ _id: false })
+export class TriageAnalysis {
+  @Prop({ required: true, type: String, enum: TRIAGE_PRIORITIES })
+  priority!: TriagePriority;
+
+  @Prop({ type: [RedFlagSchema], default: [] })
+  redFlags!: RedFlag[];
+
+  @Prop({ trim: true })
+  aiSummary?: string;
+
+  @Prop({ required: true, min: 0 })
+  analysisDurationMs!: number;
+
+  @Prop({ required: true, default: false })
+  guardrailApplied!: boolean;
+}
+
+export const TriageAnalysisSchema =
+  SchemaFactory.createForClass(TriageAnalysis);
+
+export type TriageSessionDocument = HydratedDocument<TriageSession>;
+
+@Schema({ timestamps: true })
+export class TriageSession {
+  @Prop({ type: Types.ObjectId, ref: 'Patient', required: true, index: true })
+  patientId!: Types.ObjectId;
+
+  @Prop({ required: true, type: String, enum: Specialty })
+  specialty!: Specialty;
+
+  @Prop({
+    required: true,
+    type: String,
+    enum: TRIAGE_SESSION_STATUSES,
+    default: 'IN_PROGRESS',
+  })
+  status!: TriageSessionStatus;
+
+  @Prop({ type: [TriageAnswerSchema], default: [] })
+  answers!: TriageAnswer[];
+
+  @Prop({ type: TriageAnalysisSchema })
+  analysis?: TriageAnalysis;
+
+  @Prop({ type: Date })
+  completedAt?: Date;
+
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export const TriageSessionSchema = SchemaFactory.createForClass(TriageSession);
+
+TriageSessionSchema.index({ patientId: 1, status: 1 });

--- a/src/triage/schemas/triage-session.schema.ts
+++ b/src/triage/schemas/triage-session.schema.ts
@@ -5,6 +5,8 @@ import { Specialty } from '../../common/enums/specialty.enum';
 export const TRIAGE_SESSION_STATUSES = [
   'IN_PROGRESS',
   'COMPLETED',
+  'CANCELED',
+  'EXPIRED',
   'FAILED',
 ] as const;
 
@@ -102,6 +104,12 @@ export class TriageSession {
   @Prop({ type: Date })
   completedAt?: Date;
 
+  @Prop({ type: Date })
+  canceledAt?: Date;
+
+  @Prop({ type: Date })
+  expiredAt?: Date;
+
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -109,3 +117,11 @@ export class TriageSession {
 export const TriageSessionSchema = SchemaFactory.createForClass(TriageSession);
 
 TriageSessionSchema.index({ patientId: 1, status: 1 });
+TriageSessionSchema.index(
+  { patientId: 1, specialty: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { status: 'IN_PROGRESS' },
+    name: 'uniq_active_triage_session_per_patient_specialty',
+  },
+);

--- a/src/triage/services/gemini-triage.service.spec.ts
+++ b/src/triage/services/gemini-triage.service.spec.ts
@@ -1,0 +1,165 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiService } from '../../ai/ai.service';
+import { UserRole } from '../../common/enums/user-role.enum';
+import { GeminiTriageService } from './gemini-triage.service';
+
+describe('GeminiTriageService', () => {
+  let service: GeminiTriageService;
+
+  const aiService = {
+    generateText: jest.fn(),
+  };
+
+  const configService = {
+    get: jest.fn(),
+  };
+
+  const user = {
+    userId: 'patient-1',
+    email: 'patient@example.com',
+    role: UserRole.PATIENT,
+    isActive: true,
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    configService.get.mockImplementation((key: string) => {
+      if (key === 'ai.model') {
+        return 'gemini-test-model';
+      }
+
+      return undefined;
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GeminiTriageService,
+        {
+          provide: AiService,
+          useValue: aiService,
+        },
+        {
+          provide: ConfigService,
+          useValue: configService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<GeminiTriageService>(GeminiTriageService);
+  });
+
+  it('returns parsed priority and summary from valid JSON response', async () => {
+    aiService.generateText.mockResolvedValue({
+      provider: 'gemini',
+      model: 'gemini-test-model',
+      text: '{"priority":"HIGH","summary":"Resumen neutral"}',
+      latencyMs: 10,
+      requestId: 'req-1',
+    });
+
+    const result = await service.analyzeTriage([], [], user, 'corr-1');
+
+    expect(aiService.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gemini-test-model',
+        correlationId: 'corr-1',
+        actor: {
+          actorId: user.userId,
+          actorRole: user.role,
+        },
+      }),
+    );
+    expect(result).toEqual({
+      basePriority: 'HIGH',
+      aiSummary: 'Resumen neutral',
+    });
+  });
+
+  it('falls back to default model when ai.model is missing', async () => {
+    configService.get.mockReturnValue(undefined);
+    aiService.generateText.mockResolvedValue({
+      provider: 'gemini',
+      model: 'gemini-2.5-flash',
+      text: '{"priority":"LOW"}',
+      latencyMs: 5,
+      requestId: 'req-2',
+    });
+
+    await service.analyzeTriage([], [], user);
+
+    expect(aiService.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gemini-2.5-flash',
+      }),
+    );
+  });
+
+  it('normalizes unknown priority and ignores non-string summary', async () => {
+    aiService.generateText.mockResolvedValue({
+      provider: 'gemini',
+      model: 'gemini-test-model',
+      text: '{"priority":"URGENT","summary":123}',
+      latencyMs: 12,
+      requestId: 'req-3',
+    });
+
+    const result = await service.analyzeTriage([], [], user);
+
+    expect(result).toEqual({
+      basePriority: 'LOW',
+      aiSummary: undefined,
+    });
+  });
+
+  it('extracts and parses JSON embedded in plain text', async () => {
+    aiService.generateText.mockResolvedValue({
+      provider: 'gemini',
+      model: 'gemini-test-model',
+      text: 'prefix {"priority":"MODERATE","summary":"OK"} suffix',
+      latencyMs: 9,
+      requestId: 'req-4',
+    });
+
+    const result = await service.analyzeTriage([], [], user);
+
+    expect(result).toEqual({
+      basePriority: 'MODERATE',
+      aiSummary: 'OK',
+    });
+  });
+
+  it('returns LOW with trimmed raw text when response is not parseable', async () => {
+    aiService.generateText.mockResolvedValue({
+      provider: 'gemini',
+      model: 'gemini-test-model',
+      text: '  malformed {json  ',
+      latencyMs: 9,
+      requestId: 'req-5',
+    });
+
+    const result = await service.analyzeTriage([], [], user);
+
+    expect(result).toEqual({
+      basePriority: 'LOW',
+      aiSummary: 'malformed {json',
+    });
+  });
+
+  it('returns LOW when embedded JSON is present but still invalid', async () => {
+    aiService.generateText.mockResolvedValue({
+      provider: 'gemini',
+      model: 'gemini-test-model',
+      text: 'before {"priority":"HIGH",} after',
+      latencyMs: 9,
+      requestId: 'req-6',
+    });
+
+    const result = await service.analyzeTriage([], [], user);
+
+    expect(result).toEqual({
+      basePriority: 'LOW',
+      aiSummary: 'before {"priority":"HIGH",} after',
+    });
+  });
+});

--- a/src/triage/services/gemini-triage.service.ts
+++ b/src/triage/services/gemini-triage.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AiService } from '../../ai/ai.service';
+import { RequestUser } from '../../common/interfaces/request-user.interface';
+import {
+  RedFlag,
+  TriageAnswer,
+  TriagePriority,
+} from '../schemas/triage-session.schema';
+
+type GeminiTriageResult = {
+  basePriority: TriagePriority;
+  aiSummary?: string;
+};
+
+@Injectable()
+export class GeminiTriageService {
+  private static readonly promptKey = 'triage.general_medicine.analyze';
+
+  constructor(
+    private readonly aiService: AiService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async analyzeTriage(
+    answers: TriageAnswer[],
+    redFlags: RedFlag[],
+    user: RequestUser,
+    correlationId?: string,
+  ): Promise<GeminiTriageResult> {
+    const aiResponse = await this.aiService.generateText({
+      promptKey: GeminiTriageService.promptKey,
+      promptVersion: 1,
+      model: this.configService.get<string>('ai.model') ?? 'gemini-2.5-flash',
+      systemInstruction:
+        'Eres un asistente de triage clinico. Responde solo JSON valido con las llaves priority y summary. priority debe ser LOW, MODERATE o HIGH. summary debe ser neutral, sin diagnostico, sin prescripcion y sin medicacion.',
+      inputText: JSON.stringify({ answers, redFlags }),
+      correlationId,
+      actor: {
+        actorId: user.userId,
+        actorRole: user.role,
+      },
+    });
+
+    const parsed = this.tryParseJson(aiResponse.text);
+
+    if (!parsed || typeof parsed !== 'object') {
+      return {
+        basePriority: 'LOW',
+        aiSummary: aiResponse.text?.trim() || undefined,
+      };
+    }
+
+    const priority = this.normalizePriority(
+      (parsed as Record<string, unknown>).priority,
+    );
+    const summary = (parsed as Record<string, unknown>).summary;
+
+    return {
+      basePriority: priority,
+      aiSummary: typeof summary === 'string' ? summary : undefined,
+    };
+  }
+
+  private normalizePriority(value: unknown): TriagePriority {
+    if (value === 'HIGH' || value === 'MODERATE' || value === 'LOW') {
+      return value;
+    }
+
+    return 'LOW';
+  }
+
+  private tryParseJson(value: string): unknown {
+    try {
+      return JSON.parse(value);
+    } catch {
+      const first = value.indexOf('{');
+      const last = value.lastIndexOf('}');
+      if (first < 0 || last <= first) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(value.slice(first, last + 1));
+      } catch {
+        return null;
+      }
+    }
+  }
+}

--- a/src/triage/services/guardrail.service.spec.ts
+++ b/src/triage/services/guardrail.service.spec.ts
@@ -1,0 +1,44 @@
+import { GuardrailService } from './guardrail.service';
+
+describe('GuardrailService', () => {
+  const service = new GuardrailService();
+
+  it('detects diagnosis and prescription language in at least 10 unsafe samples', () => {
+    const unsafeSamples = [
+      'Se realiza diagnostico de migraña.',
+      'El paciente padece de bronquitis.',
+      'Tiene una neumonia adquirida.',
+      'Presenta cuadro de gastroenteritis.',
+      'Es compatible con influenza.',
+      'Debe tomar ibuprofeno cada 8 horas.',
+      'Se recomienda administrar antibiotico.',
+      'Se debe recetar paracetamol.',
+      'Es asma moderada.',
+      'Sufre de hipertension arterial.',
+    ];
+
+    for (const text of unsafeSamples) {
+      const result = service.check(text);
+      expect(result.safe).toBe(false);
+      expect(result.violations.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('classifies urgency-only summaries as safe', () => {
+    const safeSamples = [
+      'Prioridad alta por sintomas de alarma, acudir a urgencias hoy.',
+      'Prioridad moderada, se recomienda valoracion medica en las proximas horas.',
+      'Prioridad baja, continuar observacion y seguimiento de sintomas.',
+    ];
+
+    for (const text of safeSamples) {
+      const result = service.check(text);
+      expect(result).toEqual({ safe: true, violations: [] });
+    }
+  });
+
+  it('returns safe for empty content', () => {
+    expect(service.check('')).toEqual({ safe: true, violations: [] });
+    expect(service.check('   ')).toEqual({ safe: true, violations: [] });
+  });
+});

--- a/src/triage/services/guardrail.service.ts
+++ b/src/triage/services/guardrail.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export type GuardrailResult = {
+  safe: boolean;
+  violations: string[];
+};
+
+type GuardrailRuleCategory = {
+  id: string;
+  label: string;
+  patterns: string[];
+};
+
+type GuardrailRulesCatalog = {
+  version: string;
+  categories: GuardrailRuleCategory[];
+};
+
+const GUARDRAIL_RULES_CANDIDATE_PATHS = [
+  resolve(__dirname, '../rules/guardrail-rules.json'),
+  resolve(process.cwd(), 'src/triage/rules/guardrail-rules.json'),
+];
+
+function loadGuardrailRules(): GuardrailRulesCatalog {
+  const rulesPath = GUARDRAIL_RULES_CANDIDATE_PATHS.find((candidatePath) =>
+    existsSync(candidatePath),
+  );
+
+  if (!rulesPath) {
+    throw new Error('No se encontro el catalogo de reglas de guardrail');
+  }
+
+  const rulesRaw = readFileSync(rulesPath, 'utf-8');
+  return JSON.parse(rulesRaw) as GuardrailRulesCatalog;
+}
+
+@Injectable()
+export class GuardrailService {
+  private readonly rulesCatalog = loadGuardrailRules();
+
+  check(text: string): GuardrailResult {
+    if (!text || text.trim().length === 0) {
+      return { safe: true, violations: [] };
+    }
+
+    const violations: string[] = [];
+
+    for (const category of this.rulesCatalog.categories) {
+      for (const pattern of category.patterns) {
+        const regex = new RegExp(pattern, 'iu');
+        if (regex.test(text)) {
+          violations.push(`${category.id}:${pattern}`);
+        }
+      }
+    }
+
+    return {
+      safe: violations.length === 0,
+      violations,
+    };
+  }
+}

--- a/src/triage/services/red-flags.engine.spec.ts
+++ b/src/triage/services/red-flags.engine.spec.ts
@@ -1,0 +1,192 @@
+import { Specialty } from '../../common/enums/specialty.enum';
+import { RedFlagsEngine } from '../engines/red-flags.engine';
+
+describe('RedFlagsEngine', () => {
+  const createAnswer = (questionId: string, answerValue: unknown) => ({
+    questionId,
+    questionText: questionId,
+    answerValue,
+    answeredAt: new Date(),
+  });
+
+  it('detects RF-MG-001 for chest pain plus breathing difficulty', () => {
+    const result = RedFlagsEngine.evaluate(
+      [
+        createAnswer('MG-Q1', 'dolor toracico desde hoy'),
+        createAnswer('MG-Q5', 'dificultad para respirar'),
+      ],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'RF-MG-001', severity: 'CRITICAL' }),
+      ]),
+    );
+  });
+
+  it('detects RF-MG-002 for syncope or loss of consciousness', () => {
+    const result = RedFlagsEngine.evaluate(
+      [createAnswer('MG-Q1', 'tuve un sincope en la tarde')],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'RF-MG-002', severity: 'CRITICAL' }),
+      ]),
+    );
+  });
+
+  it('detects RF-MG-003 for fever over 39C plus neck stiffness', () => {
+    const result = RedFlagsEngine.evaluate(
+      [createAnswer('MG-Q1', 'fiebre de 40 c y rigidez de nuca')],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'RF-MG-003', severity: 'CRITICAL' }),
+      ]),
+    );
+  });
+
+  it('detects RF-MG-004 for sudden severe abdominal pain', () => {
+    const result = RedFlagsEngine.evaluate(
+      [createAnswer('MG-Q1', 'dolor abdominal intenso de inicio subito')],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'RF-MG-004', severity: 'CRITICAL' }),
+      ]),
+    );
+  });
+
+  it('detects RF-MG-005 for sudden visual disturbances', () => {
+    const result = RedFlagsEngine.evaluate(
+      [createAnswer('MG-Q1', 'presenta vision borrosa repentina')],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'RF-MG-005', severity: 'WARNING' }),
+      ]),
+    );
+  });
+
+  it('returns empty array when there are no matching risk combinations', () => {
+    const result = RedFlagsEngine.evaluate(
+      [
+        createAnswer('MG-Q1', 'dolor muscular leve'),
+        createAnswer('MG-Q2', '2 dias'),
+      ],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for non general medicine specialties', () => {
+    const result = RedFlagsEngine.evaluate(
+      [createAnswer('OD-Q1', 'dolor dental')],
+      Specialty.ODONTOLOGY,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('handles numeric, boolean and unsupported answer values safely', () => {
+    const result = RedFlagsEngine.evaluate(
+      [
+        createAnswer('MG-Q1', 'fiebre de 40 c'),
+        createAnswer('MG-Q3', 8),
+        createAnswer('MG-Q4', 'rigidez de nuca'),
+        createAnswer('MG-Q5', true),
+        createAnswer('MG-Q2', { raw: 'unsupported' }),
+      ],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'RF-MG-003', severity: 'CRITICAL' }),
+      ]),
+    );
+  });
+
+  it('returns empty array when normalized values are empty after parsing', () => {
+    const result = RedFlagsEngine.evaluate(
+      [createAnswer('MG-Q1', { text: 'unsupported-object' })],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns multiple flags when multiple combinations are present', () => {
+    const result = RedFlagsEngine.evaluate(
+      [
+        createAnswer(
+          'MG-Q1',
+          'dolor toracico y dificultad para respirar, ademas fiebre de 40 c y rigidez de nuca',
+        ),
+        createAnswer('MG-Q2', 'inicio subito'),
+      ],
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    const detectedCodes = result.map((flag) => flag.code);
+    expect(detectedCodes).toEqual(
+      expect.arrayContaining(['RF-MG-001', 'RF-MG-003']),
+    );
+    expect(detectedCodes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('deduplicates repeated codes if catalog contains duplicated rules', () => {
+    const catalog = (
+      RedFlagsEngine as unknown as {
+        mgCatalog: {
+          rules: Array<{
+            code: string;
+            severity: 'CRITICAL' | 'WARNING' | 'INFO';
+            evidence: string;
+            questionScope?: string[];
+            allOf: Array<{ anyOf: string[] }>;
+          }>;
+        };
+      }
+    ).mgCatalog;
+
+    const duplicateRule = {
+      code: 'RF-MG-001',
+      severity: 'CRITICAL' as const,
+      evidence: 'Duplicated for test',
+      questionScope: ['MG-Q1', 'MG-Q5'],
+      allOf: [
+        { anyOf: ['dolor\\s+torac'] },
+        { anyOf: ['dificultad\\s+para\\s+respirar'] },
+      ],
+    };
+
+    catalog.rules.push(duplicateRule);
+
+    try {
+      const result = RedFlagsEngine.evaluate(
+        [
+          createAnswer('MG-Q1', 'dolor toracico'),
+          createAnswer('MG-Q5', 'dificultad para respirar'),
+        ],
+        Specialty.GENERAL_MEDICINE,
+      );
+
+      expect(result.filter((flag) => flag.code === 'RF-MG-001')).toHaveLength(
+        1,
+      );
+    } finally {
+      catalog.rules.pop();
+    }
+  });
+});

--- a/src/triage/triage.controller.spec.ts
+++ b/src/triage/triage.controller.spec.ts
@@ -10,6 +10,7 @@ describe('TriageController', () => {
   let service: {
     createSession: jest.Mock;
     getActiveSessions: jest.Mock;
+    getSessionDetail: jest.Mock;
     saveAnswers: jest.Mock;
     analyzeSession: jest.Mock;
     cancelSession: jest.Mock;
@@ -19,6 +20,7 @@ describe('TriageController', () => {
     service = {
       createSession: jest.fn(),
       getActiveSessions: jest.fn(),
+      getSessionDetail: jest.fn(),
       saveAnswers: jest.fn(),
       analyzeSession: jest.fn(),
       cancelSession: jest.fn(),
@@ -151,6 +153,34 @@ describe('TriageController', () => {
       priority: 'HIGH',
       redFlags: [],
       message: 'ok',
+    });
+  });
+
+  it('getSessionDetail should call service', async () => {
+    service.getSessionDetail.mockResolvedValue({
+      sessionId: 's1',
+      status: 'IN_PROGRESS',
+    });
+
+    const request = {
+      user: {
+        userId: 'p1',
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      correlationId: 'corr-detail',
+    } as unknown as RequestContext;
+
+    const result = await controller.getSessionDetail(request, 's1');
+
+    expect(service.getSessionDetail).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ userId: 'p1' }),
+    );
+    expect(result).toEqual({
+      sessionId: 's1',
+      status: 'IN_PROGRESS',
     });
   });
 

--- a/src/triage/triage.controller.spec.ts
+++ b/src/triage/triage.controller.spec.ts
@@ -9,15 +9,19 @@ describe('TriageController', () => {
   let controller: TriageController;
   let service: {
     createSession: jest.Mock;
+    getActiveSessions: jest.Mock;
     saveAnswers: jest.Mock;
     analyzeSession: jest.Mock;
+    cancelSession: jest.Mock;
   };
 
   beforeEach(async () => {
     service = {
       createSession: jest.fn(),
+      getActiveSessions: jest.fn(),
       saveAnswers: jest.fn(),
       analyzeSession: jest.fn(),
+      cancelSession: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -87,6 +91,36 @@ describe('TriageController', () => {
     });
   });
 
+  it('getActiveSessions should call service', async () => {
+    service.getActiveSessions.mockResolvedValue({
+      items: [{ id: 's1', specialty: Specialty.GENERAL_MEDICINE }],
+      total: 1,
+    });
+
+    const request = {
+      user: {
+        userId: 'p1',
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      correlationId: 'corr-2.1',
+    } as unknown as RequestContext;
+
+    const result = await controller.getActiveSessions(request, {
+      specialty: Specialty.GENERAL_MEDICINE,
+    });
+
+    expect(service.getActiveSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'p1' }),
+      Specialty.GENERAL_MEDICINE,
+    );
+    expect(result).toEqual({
+      items: [{ id: 's1', specialty: Specialty.GENERAL_MEDICINE }],
+      total: 1,
+    });
+  });
+
   it('analyzeSession should call service', async () => {
     service.analyzeSession.mockResolvedValue({
       sessionId: 's1',
@@ -117,6 +151,37 @@ describe('TriageController', () => {
       priority: 'HIGH',
       redFlags: [],
       message: 'ok',
+    });
+  });
+
+  it('cancelSession should call service', async () => {
+    service.cancelSession.mockResolvedValue({
+      sessionId: 's1',
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'CANCELED',
+    });
+
+    const request = {
+      user: {
+        userId: 'p1',
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      correlationId: 'corr-4',
+    } as unknown as RequestContext;
+
+    const result = await controller.cancelSession(request, 's1');
+
+    expect(service.cancelSession).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ userId: 'p1' }),
+      'corr-4',
+    );
+    expect(result).toEqual({
+      sessionId: 's1',
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'CANCELED',
     });
   });
 });

--- a/src/triage/triage.controller.spec.ts
+++ b/src/triage/triage.controller.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Specialty } from '../common/enums/specialty.enum';
+import { UserRole } from '../common/enums/user-role.enum';
+import type { RequestContext } from '../common/interfaces/request-context.interface';
+import { TriageController } from './triage.controller';
+import { TriageService } from './triage.service';
+
+describe('TriageController', () => {
+  let controller: TriageController;
+  let service: {
+    createSession: jest.Mock;
+    saveAnswers: jest.Mock;
+    analyzeSession: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    service = {
+      createSession: jest.fn(),
+      saveAnswers: jest.fn(),
+      analyzeSession: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TriageController],
+      providers: [{ provide: TriageService, useValue: service }],
+    }).compile();
+
+    controller = module.get<TriageController>(TriageController);
+  });
+
+  it('createSession should call service', async () => {
+    service.createSession.mockResolvedValue({ sessionId: 's1' });
+
+    const request = {
+      user: {
+        userId: 'p1',
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      correlationId: 'corr-1',
+    } as unknown as RequestContext;
+
+    const result = await controller.createSession(request, {
+      specialty: Specialty.GENERAL_MEDICINE,
+    });
+
+    expect(service.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'p1' }),
+      { specialty: Specialty.GENERAL_MEDICINE },
+      'corr-1',
+    );
+    expect(result).toEqual({ sessionId: 's1' });
+  });
+
+  it('saveAnswers should call service', async () => {
+    service.saveAnswers.mockResolvedValue({
+      sessionId: 's1',
+      answersCount: 1,
+      isComplete: false,
+    });
+
+    const request = {
+      user: {
+        userId: 'p1',
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      correlationId: 'corr-2',
+    } as unknown as RequestContext;
+
+    const result = await controller.saveAnswers(request, 's1', {
+      answers: [{ questionId: 'MG-Q1', answerValue: 'si' }],
+    });
+
+    expect(service.saveAnswers).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ userId: 'p1' }),
+      { answers: [{ questionId: 'MG-Q1', answerValue: 'si' }] },
+      'corr-2',
+    );
+    expect(result).toEqual({
+      sessionId: 's1',
+      answersCount: 1,
+      isComplete: false,
+    });
+  });
+
+  it('analyzeSession should call service', async () => {
+    service.analyzeSession.mockResolvedValue({
+      sessionId: 's1',
+      priority: 'HIGH',
+      redFlags: [],
+      message: 'ok',
+    });
+
+    const request = {
+      user: {
+        userId: 'p1',
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      correlationId: 'corr-3',
+    } as unknown as RequestContext;
+
+    const result = await controller.analyzeSession(request, 's1');
+
+    expect(service.analyzeSession).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ userId: 'p1' }),
+      'corr-3',
+    );
+    expect(result).toEqual({
+      sessionId: 's1',
+      priority: 'HIGH',
+      redFlags: [],
+      message: 'ok',
+    });
+  });
+});

--- a/src/triage/triage.controller.ts
+++ b/src/triage/triage.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, HttpCode, Param, Post, Req } from '@nestjs/common';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '../common/enums/user-role.enum';
+import type { RequestContext } from '../common/interfaces/request-context.interface';
+import { CreateTriageSessionDto } from './dto/create-triage-session.dto';
+import { SaveTriageAnswersDto } from './dto/save-triage-answers.dto';
+import { TriageService } from './triage.service';
+
+@Controller('triage')
+export class TriageController {
+  constructor(private readonly triageService: TriageService) {}
+
+  @Post('sessions')
+  @Roles(UserRole.PATIENT)
+  createSession(
+    @Req() req: RequestContext,
+    @Body() dto: CreateTriageSessionDto,
+  ) {
+    return this.triageService.createSession(req.user!, dto, req.correlationId);
+  }
+
+  @Post('sessions/:sessionId/answers')
+  @HttpCode(200)
+  @Roles(UserRole.PATIENT)
+  saveAnswers(
+    @Req() req: RequestContext,
+    @Param('sessionId') sessionId: string,
+    @Body() dto: SaveTriageAnswersDto,
+  ) {
+    return this.triageService.saveAnswers(
+      sessionId,
+      req.user!,
+      dto,
+      req.correlationId,
+    );
+  }
+
+  @Post('sessions/:sessionId/analyze')
+  @HttpCode(200)
+  @Roles(UserRole.PATIENT)
+  analyzeSession(
+    @Req() req: RequestContext,
+    @Param('sessionId') sessionId: string,
+  ) {
+    return this.triageService.analyzeSession(
+      sessionId,
+      req.user!,
+      req.correlationId,
+    );
+  }
+}

--- a/src/triage/triage.controller.ts
+++ b/src/triage/triage.controller.ts
@@ -1,17 +1,105 @@
-import { Body, Controller, HttpCode, Param, Post, Req } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
 import { Roles } from '../common/decorators/roles.decorator';
 import { UserRole } from '../common/enums/user-role.enum';
 import type { RequestContext } from '../common/interfaces/request-context.interface';
 import { CreateTriageSessionDto } from './dto/create-triage-session.dto';
+import { GetActiveTriageSessionsDto } from './dto/get-active-triage-sessions.dto';
 import { SaveTriageAnswersDto } from './dto/save-triage-answers.dto';
 import { TriageService } from './triage.service';
 
+@ApiTags('Triage')
+@ApiBearerAuth()
 @Controller('triage')
 export class TriageController {
   constructor(private readonly triageService: TriageService) {}
 
   @Post('sessions')
   @Roles(UserRole.PATIENT)
+  @ApiOperation({
+    summary: 'Crear sesion de triage',
+    description:
+      'Crea una sesion en estado IN_PROGRESS para el paciente autenticado y la especialidad indicada.',
+  })
+  @ApiCreatedResponse({
+    description: 'Sesion creada correctamente',
+    schema: {
+      example: {
+        sessionId: '680f0493bba79f530f7486f1',
+        specialty: 'GENERAL_MEDICINE',
+        status: 'IN_PROGRESS',
+        questions: [
+          {
+            questionId: 'MG-Q1',
+            questionText: 'Cual es tu sintoma principal?',
+          },
+        ],
+        totalQuestions: 5,
+        answeredCount: 0,
+        remainingQuestions: 5,
+        progressPercent: 0,
+        nextQuestionId: 'MG-Q1',
+        isComplete: false,
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Payload invalido o specialty fuera del enum permitido',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: [
+          'specialty must be one of the following values: GENERAL_MEDICINE, ODONTOLOGY',
+        ],
+        path: '/v1/triage/sessions',
+        timestamp: '2026-04-07T18:20:00.000Z',
+        correlation_id: 'c4f8d2e0-2b85-4b3e-94c0-2d0cb03c34fd',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'JWT ausente o invalido' })
+  @ApiForbiddenResponse({
+    description: 'El usuario autenticado no tiene rol PATIENT',
+  })
+  @ApiConflictResponse({
+    description:
+      'Ya existe una sesion IN_PROGRESS para patient+specialty; usar existingSessionId para reanudar',
+    schema: {
+      example: {
+        statusCode: 409,
+        errorCode: 'TRIAGE_SESSION_IN_PROGRESS',
+        specialty: 'GENERAL_MEDICINE',
+        existingSessionId: '680f0493bba79f530f7486f1',
+        status: 'IN_PROGRESS',
+        message: 'Ya existe una sesion de triage en progreso para esta especialidad',
+        path: '/v1/triage/sessions',
+        timestamp: '2026-04-07T18:20:00.000Z',
+        correlation_id: 'e65fd6f0-966d-4d67-9d0b-f0668f752b17',
+      },
+    },
+  })
   createSession(
     @Req() req: RequestContext,
     @Body() dto: CreateTriageSessionDto,
@@ -19,9 +107,82 @@ export class TriageController {
     return this.triageService.createSession(req.user!, dto, req.correlationId);
   }
 
+  @Get('sessions/active')
+  @Roles(UserRole.PATIENT)
+  @ApiOperation({
+    summary: 'Listar sesiones activas',
+    description:
+      'Retorna sesiones IN_PROGRESS del paciente autenticado; opcionalmente filtra por specialty.',
+  })
+  @ApiOkResponse({
+    description: 'Sesiones activas retornadas correctamente',
+    schema: {
+      example: {
+        items: [
+          {
+            id: '680f0493bba79f530f7486f1',
+            specialty: 'GENERAL_MEDICINE',
+            status: 'IN_PROGRESS',
+            currentStep: 2,
+            totalSteps: 5,
+            currentQuestionId: 'MG-Q2',
+            isComplete: false,
+            createdAt: '2026-04-07T18:18:00.000Z',
+            updatedAt: '2026-04-07T18:19:10.000Z',
+          },
+        ],
+        total: 1,
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Filtro de specialty invalido',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: [
+          'specialty must be one of the following values: GENERAL_MEDICINE, ODONTOLOGY',
+        ],
+        path: '/v1/triage/sessions/active?specialty=DENTISTRY',
+        timestamp: '2026-04-07T18:20:00.000Z',
+        correlation_id: '4aafdfd1-4fd2-4f6c-acf5-d74642bdf8d6',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'JWT ausente o invalido' })
+  @ApiForbiddenResponse({
+    description: 'El usuario autenticado no tiene rol PATIENT',
+  })
+  getActiveSessions(
+    @Req() req: RequestContext,
+    @Query() query: GetActiveTriageSessionsDto,
+  ) {
+    return this.triageService.getActiveSessions(req.user!, query.specialty);
+  }
+
   @Post('sessions/:sessionId/answers')
   @HttpCode(200)
   @Roles(UserRole.PATIENT)
+  @ApiOperation({ summary: 'Guardar respuestas de triage' })
+  @ApiOkResponse({
+    description: 'Respuestas guardadas y progreso actualizado',
+    schema: {
+      example: {
+        sessionId: '680f0493bba79f530f7486f1',
+        answersCount: 2,
+        isComplete: false,
+        totalQuestions: 5,
+        answeredCount: 2,
+        remainingQuestions: 3,
+        progressPercent: 40,
+        nextQuestionId: 'MG-Q3',
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: 'Payload invalido o estado no permitido' })
+  @ApiUnauthorizedResponse({ description: 'JWT ausente o invalido' })
+  @ApiForbiddenResponse({ description: 'El usuario autenticado no tiene rol PATIENT' })
+  @ApiNotFoundResponse({ description: 'Sesion no encontrada o no pertenece al paciente' })
   saveAnswers(
     @Req() req: RequestContext,
     @Param('sessionId') sessionId: string,
@@ -38,6 +199,24 @@ export class TriageController {
   @Post('sessions/:sessionId/analyze')
   @HttpCode(200)
   @Roles(UserRole.PATIENT)
+  @ApiOperation({ summary: 'Analizar sesion de triage' })
+  @ApiOkResponse({
+    description: 'Sesion analizada y caso enviado a cola medica',
+    schema: {
+      example: {
+        sessionId: '680f0493bba79f530f7486f1',
+        priority: 'MODERATE',
+        redFlags: [],
+        message: 'Analisis de triage completado. Tu caso fue enviado a la cola medica.',
+        highPriorityAlert: false,
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: 'Sesion invalida o no en progreso' })
+  @ApiUnauthorizedResponse({ description: 'JWT ausente o invalido' })
+  @ApiForbiddenResponse({ description: 'El usuario autenticado no tiene rol PATIENT' })
+  @ApiNotFoundResponse({ description: 'Sesion no encontrada o no pertenece al paciente' })
+  @ApiUnprocessableEntityResponse({ description: 'La sesion no tiene todas las respuestas requeridas' })
   analyzeSession(
     @Req() req: RequestContext,
     @Param('sessionId') sessionId: string,
@@ -47,5 +226,40 @@ export class TriageController {
       req.user!,
       req.correlationId,
     );
+  }
+
+  @Patch('sessions/:sessionId/cancel')
+  @HttpCode(200)
+  @Roles(UserRole.PATIENT)
+  @ApiOperation({ summary: 'Cancelar sesion de triage en progreso' })
+  @ApiOkResponse({
+    description: 'Sesion cancelada correctamente',
+    schema: {
+      example: {
+        sessionId: '680f0493bba79f530f7486f1',
+        specialty: 'GENERAL_MEDICINE',
+        status: 'CANCELED',
+        canceledAt: '2026-04-07T18:20:00.000Z',
+        message: 'Sesion de triage cancelada correctamente',
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'La sesion no esta en estado IN_PROGRESS',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'Solo se pueden cancelar sesiones en progreso',
+        path: '/v1/triage/sessions/680f0493bba79f530f7486f1/cancel',
+        timestamp: '2026-04-07T18:20:00.000Z',
+        correlation_id: '09f80178-6f68-4967-a7ec-6016ea03d11a',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'JWT ausente o invalido' })
+  @ApiForbiddenResponse({ description: 'El usuario autenticado no tiene rol PATIENT' })
+  @ApiNotFoundResponse({ description: 'Sesion no encontrada o no pertenece al paciente' })
+  cancelSession(@Req() req: RequestContext, @Param('sessionId') sessionId: string) {
+    return this.triageService.cancelSession(sessionId, req.user!, req.correlationId);
   }
 }

--- a/src/triage/triage.controller.ts
+++ b/src/triage/triage.controller.ts
@@ -18,6 +18,8 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
+  ApiServiceUnavailableResponse,
   ApiTags,
   ApiUnauthorizedResponse,
   ApiUnprocessableEntityResponse,
@@ -160,6 +162,84 @@ export class TriageController {
     return this.triageService.getActiveSessions(req.user!, query.specialty);
   }
 
+  @Get('sessions/:sessionId')
+  @Roles(UserRole.PATIENT)
+  @ApiOperation({
+    summary: 'Obtener detalle de sesion de triage',
+    description:
+      'Retorna la sesion de triage del paciente autenticado con metadatos completos de preguntas para hidratar y reanudar el cuestionario en cliente movil.',
+  })
+  @ApiParam({
+    name: 'sessionId',
+    description: 'Id de la sesion de triage',
+    example: '680f0493bba79f530f7486f1',
+  })
+  @ApiOkResponse({
+    description: 'Detalle de sesion retornado correctamente',
+    schema: {
+      example: {
+        id: '680f0493bba79f530f7486f1',
+        sessionId: '680f0493bba79f530f7486f1',
+        specialty: 'GENERAL_MEDICINE',
+        status: 'IN_PROGRESS',
+        isComplete: false,
+        currentQuestionId: 'MG-Q2',
+        currentStep: 2,
+        totalSteps: 5,
+        totalQuestions: 5,
+        nextQuestionId: 'MG-Q2',
+        questions: [
+          {
+            id: 'MG-Q1',
+            questionId: 'MG-Q1',
+            title: 'Sintoma principal',
+            questionText: 'Que sintoma principal presentas hoy?',
+            description:
+              'Selecciona el sintoma que describe mejor tu situacion.',
+            type: 'SINGLE_CHOICE',
+            options: [
+              {
+                id: 'MG-Q1-HEADACHE',
+                label: 'Dolor de cabeza',
+              },
+            ],
+          },
+          {
+            id: 'MG-Q3',
+            questionId: 'MG-Q3',
+            title: 'Intensidad de sintomas',
+            questionText: 'En una escala de 0 a 10, cual es la intensidad?',
+            type: 'NUMERIC_SCALE',
+            minValue: 0,
+            maxValue: 10,
+            step: 1,
+          },
+        ],
+        createdAt: '2026-04-07T18:18:00.000Z',
+        updatedAt: '2026-04-07T18:19:10.000Z',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'JWT ausente o invalido' })
+  @ApiForbiddenResponse({
+    description: 'El usuario autenticado no tiene rol PATIENT',
+  })
+  @ApiNotFoundResponse({
+    description: 'Sesion no encontrada o no pertenece al paciente',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Sesion de triage no encontrada',
+        path: '/v1/triage/sessions/680f0493bba79f530f7486f1',
+        timestamp: '2026-04-07T18:20:00.000Z',
+        correlation_id: '434e43f6-c73f-4b0f-a2da-07cd6b1dc148',
+      },
+    },
+  })
+  getSessionDetail(@Req() req: RequestContext, @Param('sessionId') sessionId: string) {
+    return this.triageService.getSessionDetail(sessionId, req.user!);
+  }
+
   @Post('sessions/:sessionId/answers')
   @HttpCode(200)
   @Roles(UserRole.PATIENT)
@@ -217,6 +297,21 @@ export class TriageController {
   @ApiForbiddenResponse({ description: 'El usuario autenticado no tiene rol PATIENT' })
   @ApiNotFoundResponse({ description: 'Sesion no encontrada o no pertenece al paciente' })
   @ApiUnprocessableEntityResponse({ description: 'La sesion no tiene todas las respuestas requeridas' })
+  @ApiServiceUnavailableResponse({
+    description: 'Dependencia de analisis no disponible o ruleset ausente',
+    schema: {
+      example: {
+        statusCode: 503,
+        errorCode: 'TRIAGE_ANALYSIS_DEPENDENCY_UNAVAILABLE',
+        specialty: 'GENERAL_MEDICINE',
+        sessionId: '680f0493bba79f530f7486f1',
+        message: 'No fue posible completar el analisis de triage en este momento',
+        path: '/v1/triage/sessions/680f0493bba79f530f7486f1/analyze',
+        timestamp: '2026-04-11T10:00:00.000Z',
+        correlation_id: 'mobile-mntx90rg-gpe1oido',
+      },
+    },
+  })
   analyzeSession(
     @Req() req: RequestContext,
     @Param('sessionId') sessionId: string,

--- a/src/triage/triage.module.ts
+++ b/src/triage/triage.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AiModule } from '../ai/ai.module';
+import { ConsultationsModule } from '../consultations/consultations.module';
+import { TriageController } from './triage.controller';
+import { TriageQuestionsRepository } from './questions/triage-questions.repository';
+import {
+  TriageSession,
+  TriageSessionSchema,
+} from './schemas/triage-session.schema';
+import { GeminiTriageService } from './services/gemini-triage.service';
+import { GuardrailService } from './services/guardrail.service';
+import { TriageService } from './triage.service';
+
+@Module({
+  imports: [
+    AiModule,
+    ConsultationsModule,
+    MongooseModule.forFeature([
+      { name: TriageSession.name, schema: TriageSessionSchema },
+    ]),
+  ],
+  controllers: [TriageController],
+  providers: [
+    TriageService,
+    TriageQuestionsRepository,
+    GuardrailService,
+    GeminiTriageService,
+  ],
+  exports: [TriageService, TriageQuestionsRepository, MongooseModule],
+})
+export class TriageModule {}

--- a/src/triage/triage.service.spec.ts
+++ b/src/triage/triage.service.spec.ts
@@ -2,7 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   Logger,
-  ServiceUnavailableException,
+  NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { getModelToken } from '@nestjs/mongoose';
@@ -421,6 +421,104 @@ describe('TriageService', () => {
     });
   });
 
+  it('should return session detail with full question metadata for owner', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        _id: sessionId,
+        specialty: Specialty.GENERAL_MEDICINE,
+        status: 'IN_PROGRESS',
+        answers: [{ questionId: 'MG-Q1', answerValue: true }],
+        createdAt: new Date('2026-04-07T18:00:00.000Z'),
+        updatedAt: new Date('2026-04-07T18:01:00.000Z'),
+      }),
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue([
+      'MG-Q1',
+      'MG-Q2',
+      'MG-Q3',
+    ]);
+    triageQuestionsRepository.getQuestionsBySpecialty.mockReturnValue([
+      {
+        id: 'MG-Q1',
+        questionId: 'MG-Q1',
+        title: 'Sintoma principal',
+        questionText: 'Que sintoma principal presentas hoy?',
+        type: 'SINGLE_CHOICE',
+        options: [{ id: 'MG-Q1-HEADACHE', label: 'Dolor de cabeza' }],
+      },
+      {
+        id: 'MG-Q3',
+        questionId: 'MG-Q3',
+        title: 'Intensidad de sintomas',
+        questionText: 'En una escala de 0 a 10, cual es la intensidad?',
+        type: 'NUMERIC_SCALE',
+        minValue: 0,
+        maxValue: 10,
+        step: 1,
+      },
+    ]);
+
+    const result = await service.getSessionDetail(sessionId.toString(), {
+      userId: patientId.toString(),
+      email: 'patient@example.com',
+      role: UserRole.PATIENT,
+      isActive: true,
+    });
+
+    expect(result).toEqual({
+      id: sessionId.toString(),
+      sessionId: sessionId.toString(),
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'IN_PROGRESS',
+      isComplete: false,
+      currentQuestionId: 'MG-Q2',
+      currentStep: 2,
+      totalSteps: 3,
+      totalQuestions: 3,
+      nextQuestionId: 'MG-Q2',
+      questions: [
+        {
+          id: 'MG-Q1',
+          questionId: 'MG-Q1',
+          title: 'Sintoma principal',
+          questionText: 'Que sintoma principal presentas hoy?',
+          type: 'SINGLE_CHOICE',
+          options: [{ id: 'MG-Q1-HEADACHE', label: 'Dolor de cabeza' }],
+        },
+        {
+          id: 'MG-Q3',
+          questionId: 'MG-Q3',
+          title: 'Intensidad de sintomas',
+          questionText: 'En una escala de 0 a 10, cual es la intensidad?',
+          type: 'NUMERIC_SCALE',
+          minValue: 0,
+          maxValue: 10,
+          step: 1,
+        },
+      ],
+      createdAt: '2026-04-07T18:00:00.000Z',
+      updatedAt: '2026-04-07T18:01:00.000Z',
+    });
+  });
+
+  it('should throw 404 when session detail is requested for non-owner or missing session', async () => {
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(null),
+    });
+
+    await expect(
+      service.getSessionDetail(new Types.ObjectId().toString(), {
+        userId: new Types.ObjectId().toString(),
+        email: 'other@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
   it('should cancel an in-progress session', async () => {
     const sessionId = new Types.ObjectId();
     const patientId = new Types.ObjectId();
@@ -555,6 +653,9 @@ describe('TriageService', () => {
     const warnSpy = jest
       .spyOn(Logger.prototype, 'warn')
       .mockImplementation(() => undefined);
+    const logSpy = jest
+      .spyOn(Logger.prototype, 'log')
+      .mockImplementation(() => undefined);
 
     const result = await service.analyzeSession(
       sessionId.toString(),
@@ -588,6 +689,16 @@ describe('TriageService', () => {
     expect(warnPayload.violations).toContain(
       String.raw`diagnosis:diagnostico\s+de`,
     );
+    const completedLog = logSpy.mock.calls
+      .map((call) => call[0] as string)
+      .find((payload) => payload.includes('triage.analyze.completed'));
+    expect(completedLog).toBeDefined();
+    const completedPayload = JSON.parse(completedLog!) as {
+      specialty: Specialty;
+      session_id: string;
+    };
+    expect(completedPayload.specialty).toBe(Specialty.GENERAL_MEDICINE);
+    expect(completedPayload.session_id).toBe(sessionId.toString());
   });
 
   it('should override priority to HIGH when any CRITICAL red flag exists', async () => {
@@ -618,6 +729,9 @@ describe('TriageService', () => {
     ]);
     guardrailService.check.mockReturnValue({ safe: true, violations: [] });
     consultationsService.createFromTriage.mockResolvedValue(undefined);
+    const logSpy = jest
+      .spyOn(Logger.prototype, 'log')
+      .mockImplementation(() => undefined);
 
     const result = await service.analyzeSession(sessionId.toString(), {
       userId: patientId.toString(),
@@ -628,6 +742,16 @@ describe('TriageService', () => {
 
     expect(result.priority).toBe('HIGH');
     expect(result.highPriorityAlert).toBe(true);
+    const completedLog = logSpy.mock.calls
+      .map((call) => call[0] as string)
+      .find((payload) => payload.includes('triage.analyze.completed'));
+    expect(completedLog).toBeDefined();
+    const completedPayload = JSON.parse(completedLog!) as {
+      specialty: Specialty;
+      session_id: string;
+    };
+    expect(completedPayload.specialty).toBe(Specialty.ODONTOLOGY);
+    expect(completedPayload.session_id).toBe(sessionId.toString());
   });
 
   it('should raise LOW base priority to MODERATE when WARNING red flags exist', async () => {
@@ -694,7 +818,7 @@ describe('TriageService', () => {
     triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue(['MG-Q1']);
     jest.spyOn(RedFlagsEngine, 'evaluate').mockReturnValue([]);
     geminiTriageService.analyzeTriage.mockRejectedValue(
-      new Error('provider down'),
+      new Error('invalid provider response schema'),
     );
 
     await expect(
@@ -708,8 +832,104 @@ describe('TriageService', () => {
         },
         'corr-ai-failure',
       ),
-    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    ).rejects.toMatchObject({
+      response: expect.objectContaining({
+        errorCode: 'TRIAGE_ANALYSIS_DEPENDENCY_UNAVAILABLE',
+        specialty: Specialty.GENERAL_MEDICINE,
+        sessionId: sessionId.toString(),
+      }),
+    });
 
     expect(triageSession.status).toBe('FAILED');
+  });
+
+  it('should retry and fallback to rules when transient Gemini failures persist', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    const triageSession = {
+      _id: sessionId,
+      patientId,
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'IN_PROGRESS',
+      answers: [{ questionId: 'MG-Q1', answerValue: 'dolor' }],
+      save: jest.fn().mockResolvedValue(undefined),
+      analysis: undefined,
+      completedAt: undefined,
+    };
+
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(triageSession),
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue(['MG-Q1']);
+    jest.spyOn(RedFlagsEngine, 'evaluate').mockReturnValue([]);
+    geminiTriageService.analyzeTriage.mockRejectedValue(
+      new Error('ETIMEDOUT while calling provider'),
+    );
+    guardrailService.check.mockReturnValue({ safe: true, violations: [] });
+    consultationsService.createFromTriage.mockResolvedValue(undefined);
+
+    const result = await service.analyzeSession(
+      sessionId.toString(),
+      {
+        userId: patientId.toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      'corr-ai-fallback',
+    );
+
+    expect(geminiTriageService.analyzeTriage).toHaveBeenCalledTimes(3);
+    expect(triageSession.status).toBe('COMPLETED');
+    expect(result.priority).toBe('LOW');
+    expect(result.highPriorityAlert).toBe(false);
+    expect(result.analysisMode).toBe('RULE_BASED');
+    expect(result.noticeCode).toBe(
+      'IA_TEMPORARILY_UNAVAILABLE_RULE_BASED_FALLBACK',
+    );
+  });
+
+  it('should fallback to rules with explicit no-AI message when provider is disabled', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    const triageSession = {
+      _id: sessionId,
+      patientId,
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'IN_PROGRESS',
+      answers: [{ questionId: 'MG-Q1', answerValue: 'dolor' }],
+      save: jest.fn().mockResolvedValue(undefined),
+      analysis: undefined,
+      completedAt: undefined,
+    };
+
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(triageSession),
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue(['MG-Q1']);
+    jest.spyOn(RedFlagsEngine, 'evaluate').mockReturnValue([]);
+    geminiTriageService.analyzeTriage.mockRejectedValue(
+      new Error('AI provider is disabled'),
+    );
+    guardrailService.check.mockReturnValue({ safe: true, violations: [] });
+    consultationsService.createFromTriage.mockResolvedValue(undefined);
+
+    const result = await service.analyzeSession(
+      sessionId.toString(),
+      {
+        userId: patientId.toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      'corr-ai-not-implemented',
+    );
+
+    expect(result.analysisMode).toBe('RULE_BASED');
+    expect(result.noticeCode).toBe('IA_NOT_IMPLEMENTED_RULE_BASED_FALLBACK');
+    expect(result.message).toContain(
+      'la IA no esta implementada en este entorno',
+    );
+    expect(result.priority).toBe('LOW');
   });
 });

--- a/src/triage/triage.service.spec.ts
+++ b/src/triage/triage.service.spec.ts
@@ -1,0 +1,565 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Logger,
+  ServiceUnavailableException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Types } from 'mongoose';
+import { ConsultationsService } from '../consultations/consultations.service';
+import { Specialty } from '../common/enums/specialty.enum';
+import { UserRole } from '../common/enums/user-role.enum';
+import { RedFlagsEngine } from './engines/red-flags.engine';
+import { TriageQuestionsRepository } from './questions/triage-questions.repository';
+import { GeminiTriageService } from './services/gemini-triage.service';
+import { GuardrailService } from './services/guardrail.service';
+import { TriageSession } from './schemas/triage-session.schema';
+import { TriageService } from './triage.service';
+
+function createFindOneChain(result: unknown) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue(result),
+  };
+}
+
+describe('TriageService', () => {
+  let service: TriageService;
+
+  const triageSessionModel = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  };
+
+  const triageQuestionsRepository = {
+    getQuestionsBySpecialty: jest.fn(),
+    isQuestionValid: jest.fn(),
+    getQuestionById: jest.fn(),
+    getRequiredQuestionIds: jest.fn(),
+  };
+
+  const geminiTriageService = {
+    analyzeTriage: jest.fn(),
+  };
+
+  const guardrailService = {
+    check: jest.fn(),
+  };
+
+  const consultationsService = {
+    createFromTriage: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    guardrailService.check.mockReturnValue({ safe: true, violations: [] });
+    jest.spyOn(RedFlagsEngine, 'evaluate').mockReturnValue([]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TriageService,
+        {
+          provide: getModelToken(TriageSession.name),
+          useValue: triageSessionModel,
+        },
+        {
+          provide: TriageQuestionsRepository,
+          useValue: triageQuestionsRepository,
+        },
+        {
+          provide: GeminiTriageService,
+          useValue: geminiTriageService,
+        },
+        {
+          provide: GuardrailService,
+          useValue: guardrailService,
+        },
+        {
+          provide: ConsultationsService,
+          useValue: consultationsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TriageService>(TriageService);
+  });
+
+  it('should throw 400 when patient id is invalid', async () => {
+    await expect(
+      service.createSession(
+        {
+          userId: 'invalid',
+          email: 'patient@example.com',
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        { specialty: Specialty.GENERAL_MEDICINE },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('should throw 409 when there is an active session for patient and specialty', async () => {
+    triageSessionModel.findOne.mockReturnValue(
+      createFindOneChain({ _id: new Types.ObjectId() }),
+    );
+
+    await expect(
+      service.createSession(
+        {
+          userId: new Types.ObjectId().toString(),
+          email: 'patient@example.com',
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        { specialty: Specialty.GENERAL_MEDICINE },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('should create a new triage session and return questions', async () => {
+    const sessionId = new Types.ObjectId();
+    triageSessionModel.findOne.mockReturnValue(createFindOneChain(null));
+    triageSessionModel.create.mockResolvedValue([
+      {
+        _id: sessionId,
+        specialty: Specialty.GENERAL_MEDICINE,
+        status: 'IN_PROGRESS',
+      },
+    ]);
+    triageQuestionsRepository.getQuestionsBySpecialty.mockReturnValue([
+      { questionId: 'MG-Q1', questionText: 'Q1' },
+    ]);
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue([
+      'MG-Q1',
+      'MG-Q2',
+    ]);
+
+    const result = await service.createSession(
+      {
+        userId: new Types.ObjectId().toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      { specialty: Specialty.GENERAL_MEDICINE },
+      'corr-1',
+    );
+
+    expect(result).toEqual({
+      sessionId: sessionId.toString(),
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'IN_PROGRESS',
+      questions: [{ questionId: 'MG-Q1', questionText: 'Q1' }],
+      totalQuestions: 2,
+      answeredCount: 0,
+      remainingQuestions: 2,
+      progressPercent: 0,
+      nextQuestionId: 'MG-Q1',
+      isComplete: false,
+    });
+    expect(
+      triageQuestionsRepository.getQuestionsBySpecialty,
+    ).toHaveBeenCalledWith(Specialty.GENERAL_MEDICINE);
+  });
+
+  it('should throw 404 when session does not exist or does not belong to patient', async () => {
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(null),
+    });
+
+    await expect(
+      service.saveAnswers(
+        new Types.ObjectId().toString(),
+        {
+          userId: new Types.ObjectId().toString(),
+          email: 'patient@example.com',
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        { answers: [{ questionId: 'MG-Q1', answerValue: 'si' }] },
+      ),
+    ).rejects.toThrow('Sesion de triage no encontrada');
+  });
+
+  it('should throw 400 when session status is not IN_PROGRESS', async () => {
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        _id: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        status: 'COMPLETED',
+        answers: [],
+        save: jest.fn(),
+      }),
+    });
+
+    await expect(
+      service.saveAnswers(
+        new Types.ObjectId().toString(),
+        {
+          userId: new Types.ObjectId().toString(),
+          email: 'patient@example.com',
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        { answers: [{ questionId: 'MG-Q1', answerValue: 'si' }] },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('should throw 400 when question ids are invalid for session specialty', async () => {
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        _id: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        status: 'IN_PROGRESS',
+        answers: [],
+        save: jest.fn(),
+      }),
+    });
+    triageQuestionsRepository.isQuestionValid.mockReturnValue(false);
+
+    await expect(
+      service.saveAnswers(
+        new Types.ObjectId().toString(),
+        {
+          userId: new Types.ObjectId().toString(),
+          email: 'patient@example.com',
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        { answers: [{ questionId: 'OD-Q9', answerValue: 'si' }] },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('should save partial answers and return isComplete false', async () => {
+    const sessionId = new Types.ObjectId();
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        _id: sessionId,
+        specialty: Specialty.GENERAL_MEDICINE,
+        status: 'IN_PROGRESS',
+        answers: [],
+        save: saveMock,
+      }),
+    });
+    triageQuestionsRepository.isQuestionValid.mockReturnValue(true);
+    triageQuestionsRepository.getQuestionById.mockReturnValue({
+      questionId: 'MG-Q1',
+      questionText: 'Q1',
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue([
+      'MG-Q1',
+      'MG-Q2',
+    ]);
+
+    const result = await service.saveAnswers(
+      sessionId.toString(),
+      {
+        userId: new Types.ObjectId().toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      { answers: [{ questionId: 'MG-Q1', answerValue: 'si' }] },
+    );
+
+    expect(saveMock).toHaveBeenCalled();
+    expect(result).toEqual({
+      sessionId: sessionId.toString(),
+      answersCount: 1,
+      isComplete: false,
+      totalQuestions: 2,
+      answeredCount: 1,
+      remainingQuestions: 1,
+      progressPercent: 50,
+      nextQuestionId: 'MG-Q2',
+    });
+  });
+
+  it('should save answers and return isComplete true when all required questions are answered', async () => {
+    const sessionId = new Types.ObjectId();
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        _id: sessionId,
+        specialty: Specialty.GENERAL_MEDICINE,
+        status: 'IN_PROGRESS',
+        answers: [],
+        save: saveMock,
+      }),
+    });
+    triageQuestionsRepository.isQuestionValid.mockReturnValue(true);
+    triageQuestionsRepository.getQuestionById.mockImplementation(
+      (_specialty: Specialty, questionId: string) => ({
+        questionId,
+        questionText: questionId,
+      }),
+    );
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue([
+      'MG-Q1',
+      'MG-Q2',
+    ]);
+
+    const result = await service.saveAnswers(
+      sessionId.toString(),
+      {
+        userId: new Types.ObjectId().toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      {
+        answers: [
+          { questionId: 'MG-Q1', answerValue: 'si' },
+          { questionId: 'MG-Q2', answerValue: 'no' },
+        ],
+      },
+    );
+
+    expect(saveMock).toHaveBeenCalled();
+    expect(result).toEqual({
+      sessionId: sessionId.toString(),
+      answersCount: 2,
+      isComplete: true,
+      totalQuestions: 2,
+      answeredCount: 2,
+      remainingQuestions: 0,
+      progressPercent: 100,
+      nextQuestionId: null,
+    });
+  });
+
+  it('should throw 422 when trying to analyze an incomplete session', async () => {
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        _id: new Types.ObjectId(),
+        patientId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        status: 'IN_PROGRESS',
+        answers: [{ questionId: 'MG-Q1', answerValue: 'si' }],
+        save: jest.fn(),
+      }),
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue([
+      'MG-Q1',
+      'MG-Q2',
+    ]);
+
+    await expect(
+      service.analyzeSession(
+        new Types.ObjectId().toString(),
+        {
+          userId: new Types.ObjectId().toString(),
+          email: 'patient@example.com',
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        'corr-incomplete',
+      ),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+  });
+
+  it('should apply guardrail and complete session successfully for general medicine', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    const triageSession: {
+      _id: Types.ObjectId;
+      patientId: Types.ObjectId;
+      specialty: Specialty;
+      status: string;
+      answers: Array<{ questionId: string; answerValue: string }>;
+      save: jest.Mock;
+      analysis?: {
+        guardrailApplied?: boolean;
+        aiSummary?: string;
+      };
+      completedAt?: Date;
+    } = {
+      _id: sessionId,
+      patientId,
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'IN_PROGRESS',
+      answers: [{ questionId: 'MG-Q1', answerValue: 'si' }],
+      save: saveMock,
+    };
+
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(triageSession),
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue(['MG-Q1']);
+    jest.spyOn(RedFlagsEngine, 'evaluate').mockReturnValue([]);
+    geminiTriageService.analyzeTriage.mockResolvedValue({
+      basePriority: 'LOW',
+      aiSummary: 'Diagnostico probable de migraña con prescripcion sugerida',
+    });
+    guardrailService.check.mockReturnValue({
+      safe: false,
+      violations: ['diagnosis:diagnostico\\s+de'],
+    });
+    consultationsService.createFromTriage.mockResolvedValue(undefined);
+    const warnSpy = jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+
+    const result = await service.analyzeSession(
+      sessionId.toString(),
+      {
+        userId: patientId.toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      'corr-guardrail',
+    );
+
+    expect(result.priority).toBe('LOW');
+    expect(result.highPriorityAlert).toBe(false);
+    expect(triageSession.status).toBe('COMPLETED');
+    expect(triageSession.analysis?.guardrailApplied).toBe(true);
+    expect(triageSession.analysis?.aiSummary).toBeUndefined();
+    expect(consultationsService.createFromTriage).toHaveBeenCalledWith({
+      patientId,
+      triageSessionId: sessionId,
+      specialty: Specialty.GENERAL_MEDICINE,
+      priority: 'LOW',
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const warnPayloadRaw = warnSpy.mock.calls[0][0] as string;
+    const warnPayload = JSON.parse(warnPayloadRaw) as {
+      correlation_id: string;
+      violations: string[];
+    };
+    expect(warnPayload.correlation_id).toBe('corr-guardrail');
+    expect(warnPayload.violations).toContain('diagnosis:diagnostico\\s+de');
+  });
+
+  it('should override priority to HIGH when any CRITICAL red flag exists', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    const triageSession = {
+      _id: sessionId,
+      patientId,
+      specialty: Specialty.ODONTOLOGY,
+      status: 'IN_PROGRESS',
+      answers: [{ questionId: 'OD-Q1', answerValue: 'dolor' }],
+      save: jest.fn().mockResolvedValue(undefined),
+      analysis: undefined,
+      completedAt: undefined,
+    };
+
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(triageSession),
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue(['OD-Q1']);
+    jest.spyOn(RedFlagsEngine, 'evaluate').mockReturnValue([
+      {
+        code: 'RF-OD-CRIT',
+        specialty: Specialty.ODONTOLOGY,
+        severity: 'CRITICAL',
+        evidence: 'test',
+      },
+    ]);
+    guardrailService.check.mockReturnValue({ safe: true, violations: [] });
+    consultationsService.createFromTriage.mockResolvedValue(undefined);
+
+    const result = await service.analyzeSession(sessionId.toString(), {
+      userId: patientId.toString(),
+      email: 'patient@example.com',
+      role: UserRole.PATIENT,
+      isActive: true,
+    });
+
+    expect(result.priority).toBe('HIGH');
+    expect(result.highPriorityAlert).toBe(true);
+  });
+
+  it('should raise LOW base priority to MODERATE when WARNING red flags exist', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    const triageSession = {
+      _id: sessionId,
+      patientId,
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'IN_PROGRESS',
+      answers: [{ questionId: 'MG-Q1', answerValue: 'dolor' }],
+      save: jest.fn().mockResolvedValue(undefined),
+      analysis: undefined,
+      completedAt: undefined,
+    };
+
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(triageSession),
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue(['MG-Q1']);
+    jest.spyOn(RedFlagsEngine, 'evaluate').mockReturnValue([
+      {
+        code: 'RF-MG-WARN',
+        specialty: Specialty.GENERAL_MEDICINE,
+        severity: 'WARNING',
+        evidence: 'test',
+      },
+    ]);
+    geminiTriageService.analyzeTriage.mockResolvedValue({
+      basePriority: 'LOW',
+      aiSummary: 'Resumen neutral',
+    });
+    guardrailService.check.mockReturnValue({ safe: true, violations: [] });
+    consultationsService.createFromTriage.mockResolvedValue(undefined);
+
+    const result = await service.analyzeSession(sessionId.toString(), {
+      userId: patientId.toString(),
+      email: 'patient@example.com',
+      role: UserRole.PATIENT,
+      isActive: true,
+    });
+
+    expect(result.priority).toBe('MODERATE');
+    expect(result.highPriorityAlert).toBe(false);
+  });
+
+  it('should mark session FAILED and return 503 when Gemini analysis fails', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    const triageSession = {
+      _id: sessionId,
+      patientId,
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'IN_PROGRESS',
+      answers: [{ questionId: 'MG-Q1', answerValue: 'dolor' }],
+      save: jest.fn().mockResolvedValue(undefined),
+      analysis: undefined,
+      completedAt: undefined,
+    };
+
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(triageSession),
+    });
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue(['MG-Q1']);
+    jest.spyOn(RedFlagsEngine, 'evaluate').mockReturnValue([]);
+    geminiTriageService.analyzeTriage.mockRejectedValue(
+      new Error('provider down'),
+    );
+
+    await expect(
+      service.analyzeSession(
+        sessionId.toString(),
+        {
+          userId: patientId.toString(),
+          email: 'patient@example.com',
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        'corr-ai-failure',
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+
+    expect(triageSession.status).toBe('FAILED');
+  });
+});

--- a/src/triage/triage.service.spec.ts
+++ b/src/triage/triage.service.spec.ts
@@ -31,6 +31,7 @@ describe('TriageService', () => {
 
   const triageSessionModel = {
     findOne: jest.fn(),
+    find: jest.fn(),
     create: jest.fn(),
   };
 
@@ -103,21 +104,57 @@ describe('TriageService', () => {
   });
 
   it('should throw 409 when there is an active session for patient and specialty', async () => {
+    const existingId = new Types.ObjectId();
     triageSessionModel.findOne.mockReturnValue(
-      createFindOneChain({ _id: new Types.ObjectId() }),
+      createFindOneChain({ _id: existingId }),
     );
 
-    await expect(
-      service.createSession(
-        {
-          userId: new Types.ObjectId().toString(),
-          email: 'patient@example.com',
-          role: UserRole.PATIENT,
-          isActive: true,
-        },
-        { specialty: Specialty.GENERAL_MEDICINE },
-      ),
-    ).rejects.toBeInstanceOf(ConflictException);
+    const promise = service.createSession(
+      {
+        userId: new Types.ObjectId().toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      { specialty: Specialty.GENERAL_MEDICINE },
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(ConflictException);
+    await expect(promise).rejects.toMatchObject({
+      response: expect.objectContaining({
+        errorCode: 'TRIAGE_SESSION_IN_PROGRESS',
+        specialty: Specialty.GENERAL_MEDICINE,
+        existingSessionId: existingId.toString(),
+        status: 'IN_PROGRESS',
+      }),
+    });
+  });
+
+  it('should throw structured 409 when duplicate key race condition happens', async () => {
+    const existingId = new Types.ObjectId();
+
+    triageSessionModel.findOne
+      .mockReturnValueOnce(createFindOneChain(null))
+      .mockReturnValueOnce(createFindOneChain({ _id: existingId }));
+    triageSessionModel.create.mockRejectedValue({ code: 11000 });
+
+    const promise = service.createSession(
+      {
+        userId: new Types.ObjectId().toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      { specialty: Specialty.GENERAL_MEDICINE },
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(ConflictException);
+    await expect(promise).rejects.toMatchObject({
+      response: expect.objectContaining({
+        errorCode: 'TRIAGE_SESSION_IN_PROGRESS',
+        existingSessionId: existingId.toString(),
+      }),
+    });
   });
 
   it('should create a new triage session and return questions', async () => {
@@ -335,6 +372,117 @@ describe('TriageService', () => {
     });
   });
 
+  it('should list active sessions with progress data', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    triageQuestionsRepository.getRequiredQuestionIds.mockReturnValue([
+      'MG-Q1',
+      'MG-Q2',
+    ]);
+    triageSessionModel.find.mockReturnValue({
+      sort: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue([
+        {
+          _id: sessionId,
+          specialty: Specialty.GENERAL_MEDICINE,
+          status: 'IN_PROGRESS',
+          answers: [{ questionId: 'MG-Q1', answerValue: true }],
+          createdAt: new Date('2026-04-07T18:00:00.000Z'),
+          updatedAt: new Date('2026-04-07T18:01:00.000Z'),
+        },
+      ]),
+    });
+
+    const result = await service.getActiveSessions(
+      {
+        userId: patientId.toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      Specialty.GENERAL_MEDICINE,
+    );
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: sessionId.toString(),
+          specialty: Specialty.GENERAL_MEDICINE,
+          status: 'IN_PROGRESS',
+          currentStep: 2,
+          totalSteps: 2,
+          currentQuestionId: 'MG-Q2',
+          isComplete: false,
+          createdAt: '2026-04-07T18:00:00.000Z',
+          updatedAt: '2026-04-07T18:01:00.000Z',
+        },
+      ],
+      total: 1,
+    });
+  });
+
+  it('should cancel an in-progress session', async () => {
+    const sessionId = new Types.ObjectId();
+    const patientId = new Types.ObjectId();
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    const triageSession = {
+      _id: sessionId,
+      patientId,
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'IN_PROGRESS',
+      answers: [],
+      save: saveMock,
+    };
+
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(triageSession),
+    });
+
+    const result = await service.cancelSession(
+      sessionId.toString(),
+      {
+        userId: patientId.toString(),
+        email: 'patient@example.com',
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      'corr-cancel',
+    );
+
+    expect(saveMock).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      sessionId: sessionId.toString(),
+      specialty: Specialty.GENERAL_MEDICINE,
+      status: 'CANCELED',
+      message: 'Sesion de triage cancelada correctamente',
+    });
+  });
+
+  it('should reject cancel when session is not IN_PROGRESS', async () => {
+    triageSessionModel.findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({
+        _id: new Types.ObjectId(),
+        patientId: new Types.ObjectId(),
+        specialty: Specialty.GENERAL_MEDICINE,
+        status: 'COMPLETED',
+        answers: [],
+        save: jest.fn(),
+      }),
+    });
+
+    await expect(
+      service.cancelSession(
+        new Types.ObjectId().toString(),
+        {
+          userId: new Types.ObjectId().toString(),
+          email: 'patient@example.com',
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
   it('should throw 422 when trying to analyze an incomplete session', async () => {
     triageSessionModel.findOne.mockReturnValue({
       exec: jest.fn().mockResolvedValue({
@@ -401,7 +549,7 @@ describe('TriageService', () => {
     });
     guardrailService.check.mockReturnValue({
       safe: false,
-      violations: ['diagnosis:diagnostico\\s+de'],
+      violations: [String.raw`diagnosis:diagnostico\s+de`],
     });
     consultationsService.createFromTriage.mockResolvedValue(undefined);
     const warnSpy = jest
@@ -437,7 +585,9 @@ describe('TriageService', () => {
       violations: string[];
     };
     expect(warnPayload.correlation_id).toBe('corr-guardrail');
-    expect(warnPayload.violations).toContain('diagnosis:diagnostico\\s+de');
+    expect(warnPayload.violations).toContain(
+      String.raw`diagnosis:diagnostico\s+de`,
+    );
   });
 
   it('should override priority to HIGH when any CRITICAL red flag exists', async () => {

--- a/src/triage/triage.service.ts
+++ b/src/triage/triage.service.ts
@@ -1,0 +1,503 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { ConsultationsService } from '../consultations/consultations.service';
+import { Specialty } from '../common/enums/specialty.enum';
+import { RequestUser } from '../common/interfaces/request-user.interface';
+import { CreateTriageSessionDto } from './dto/create-triage-session.dto';
+import { RedFlagsEngine } from './engines/red-flags.engine';
+import { SaveTriageAnswersDto } from './dto/save-triage-answers.dto';
+import { GeminiTriageService } from './services/gemini-triage.service';
+import { GuardrailService } from './services/guardrail.service';
+import {
+  RedFlag,
+  TriagePriority,
+  TriageSession,
+  TriageSessionDocument,
+} from './schemas/triage-session.schema';
+import {
+  TriageQuestion,
+  TriageQuestionsRepository,
+} from './questions/triage-questions.repository';
+
+type CreateTriageSessionResponse = {
+  sessionId: string;
+  specialty: string;
+  status: string;
+  questions: TriageQuestion[];
+  totalQuestions: number;
+  answeredCount: number;
+  remainingQuestions: number;
+  progressPercent: number;
+  nextQuestionId: string | null;
+  isComplete: boolean;
+};
+
+type SaveTriageAnswersResponse = {
+  sessionId: string;
+  answersCount: number;
+  isComplete: boolean;
+  totalQuestions: number;
+  answeredCount: number;
+  remainingQuestions: number;
+  progressPercent: number;
+  nextQuestionId: string | null;
+};
+
+type AnalyzeTriageSessionResponse = {
+  sessionId: string;
+  priority: TriagePriority;
+  redFlags: RedFlag[];
+  message: string;
+  highPriorityAlert: boolean;
+};
+
+@Injectable()
+export class TriageService {
+  private readonly logger = new Logger(TriageService.name);
+
+  constructor(
+    @InjectModel(TriageSession.name)
+    private readonly triageSessionModel: Model<TriageSessionDocument>,
+    private readonly triageQuestionsRepository: TriageQuestionsRepository,
+    private readonly guardrailService: GuardrailService,
+    private readonly geminiTriageService: GeminiTriageService,
+    private readonly consultationsService: ConsultationsService,
+  ) {}
+
+  async createSession(
+    user: RequestUser,
+    dto: CreateTriageSessionDto,
+    correlationId?: string,
+  ): Promise<CreateTriageSessionResponse> {
+    if (!Types.ObjectId.isValid(user.userId)) {
+      throw new BadRequestException('patientId invalido');
+    }
+
+    const patientId = new Types.ObjectId(user.userId);
+    const existingSession = await this.triageSessionModel
+      .findOne({
+        patientId,
+        specialty: dto.specialty,
+        status: 'IN_PROGRESS',
+      })
+      .select('_id')
+      .lean()
+      .exec();
+
+    if (existingSession) {
+      throw new ConflictException(
+        'Ya existe una sesion de triage en progreso para esta especialidad',
+      );
+    }
+
+    const [createdSession] = await this.triageSessionModel.create([
+      {
+        patientId,
+        specialty: dto.specialty,
+        status: 'IN_PROGRESS',
+      },
+    ]);
+
+    const questions = this.triageQuestionsRepository.getQuestionsBySpecialty(
+      dto.specialty,
+    );
+    const progress = this.buildProgressState(dto.specialty, new Set<string>());
+
+    this.logger.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: 'info',
+        service: 'api',
+        endpoint_or_event: 'triage.session.created',
+        correlation_id: correlationId,
+        user_id: user.userId,
+        role: user.role,
+        specialty: dto.specialty,
+        triage_session_id: createdSession._id.toString(),
+      }),
+    );
+
+    return {
+      sessionId: createdSession._id.toString(),
+      specialty: createdSession.specialty,
+      status: createdSession.status,
+      questions,
+      totalQuestions: progress.totalQuestions,
+      answeredCount: progress.answeredCount,
+      remainingQuestions: progress.remainingQuestions,
+      progressPercent: progress.progressPercent,
+      nextQuestionId: progress.nextQuestionId,
+      isComplete: progress.isComplete,
+    };
+  }
+
+  async saveAnswers(
+    sessionId: string,
+    user: RequestUser,
+    dto: SaveTriageAnswersDto,
+    correlationId?: string,
+  ): Promise<SaveTriageAnswersResponse> {
+    if (!Types.ObjectId.isValid(sessionId)) {
+      throw new NotFoundException('Sesion de triage no encontrada');
+    }
+
+    if (!Types.ObjectId.isValid(user.userId)) {
+      throw new BadRequestException('patientId invalido');
+    }
+
+    const triageSession = await this.triageSessionModel
+      .findOne({
+        _id: new Types.ObjectId(sessionId),
+        patientId: new Types.ObjectId(user.userId),
+      })
+      .exec();
+
+    if (!triageSession) {
+      throw new NotFoundException('Sesion de triage no encontrada');
+    }
+
+    if (triageSession.status !== 'IN_PROGRESS') {
+      throw new BadRequestException('La sesion de triage no esta en progreso');
+    }
+
+    const invalidQuestionIds = dto.answers
+      .map((answer) => answer.questionId)
+      .filter(
+        (questionId) =>
+          !this.triageQuestionsRepository.isQuestionValid(
+            triageSession.specialty,
+            questionId,
+          ),
+      );
+
+    if (invalidQuestionIds.length > 0) {
+      throw new BadRequestException(
+        `questionId invalido para la especialidad de la sesion: ${invalidQuestionIds.join(', ')}`,
+      );
+    }
+
+    const answerMap = new Map(
+      triageSession.answers.map((answer) => [answer.questionId, answer]),
+    );
+
+    for (const incomingAnswer of dto.answers) {
+      const question = this.triageQuestionsRepository.getQuestionById(
+        triageSession.specialty,
+        incomingAnswer.questionId,
+      );
+
+      if (!question) {
+        continue;
+      }
+
+      answerMap.set(incomingAnswer.questionId, {
+        questionId: incomingAnswer.questionId,
+        questionText: question.questionText,
+        answerValue: incomingAnswer.answerValue,
+        answeredAt: new Date(),
+      });
+    }
+
+    const requiredQuestionIds =
+      this.triageQuestionsRepository.getRequiredQuestionIds(
+        triageSession.specialty,
+      );
+
+    triageSession.answers = requiredQuestionIds
+      .filter((questionId) => answerMap.has(questionId))
+      .map((questionId) => answerMap.get(questionId)!);
+
+    await triageSession.save();
+
+    const answeredQuestionIds = new Set(answerMap.keys());
+    const progress = this.buildProgressState(
+      triageSession.specialty,
+      answeredQuestionIds,
+    );
+
+    this.logger.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: 'info',
+        service: 'api',
+        endpoint_or_event: 'triage.answers.saved',
+        correlation_id: correlationId,
+        user_id: user.userId,
+        role: user.role,
+        specialty: triageSession.specialty,
+        triage_session_id: triageSession._id.toString(),
+        answers_count: triageSession.answers.length,
+        is_complete: progress.isComplete,
+      }),
+    );
+
+    return {
+      sessionId: triageSession._id.toString(),
+      answersCount: triageSession.answers.length,
+      isComplete: progress.isComplete,
+      totalQuestions: progress.totalQuestions,
+      answeredCount: progress.answeredCount,
+      remainingQuestions: progress.remainingQuestions,
+      progressPercent: progress.progressPercent,
+      nextQuestionId: progress.nextQuestionId,
+    };
+  }
+
+  async analyzeSession(
+    sessionId: string,
+    user: RequestUser,
+    correlationId?: string,
+  ): Promise<AnalyzeTriageSessionResponse> {
+    const triageSession = await this.getOwnedInProgressSession(sessionId, user);
+
+    if (!this.isSessionComplete(triageSession)) {
+      throw new UnprocessableEntityException(
+        'La sesion de triage no esta completa',
+      );
+    }
+
+    const startedAt = Date.now();
+    const redFlags = RedFlagsEngine.evaluate(
+      triageSession.answers,
+      triageSession.specialty,
+    );
+
+    let basePriority = this.getRuleBasedBasePriority(redFlags);
+    let aiSummary: string | undefined;
+
+    if (triageSession.specialty === Specialty.GENERAL_MEDICINE) {
+      try {
+        const aiResult = await this.geminiTriageService.analyzeTriage(
+          triageSession.answers,
+          redFlags,
+          user,
+          correlationId,
+        );
+
+        basePriority = aiResult.basePriority;
+        aiSummary = aiResult.aiSummary;
+      } catch (error: unknown) {
+        const analysisDurationMs = Date.now() - startedAt;
+        triageSession.status = 'FAILED';
+        await triageSession.save();
+
+        this.logger.error(
+          JSON.stringify({
+            timestamp: new Date().toISOString(),
+            level: 'error',
+            service: 'api',
+            endpoint_or_event: 'triage.analyze.failed',
+            correlation_id: correlationId,
+            user_id: user.userId,
+            role: user.role,
+            specialty: triageSession.specialty,
+            triage_session_id: triageSession._id.toString(),
+            latency_ms: analysisDurationMs,
+            error_message:
+              error instanceof Error ? error.message : String(error),
+          }),
+        );
+
+        throw new ServiceUnavailableException(
+          'No fue posible completar el analisis de triage en este momento',
+        );
+      }
+    }
+
+    const guardrailResult = this.guardrailService.check(aiSummary ?? '');
+    const guardrailApplied = !guardrailResult.safe;
+    if (guardrailApplied) {
+      this.logger.warn(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: 'warn',
+          service: 'api',
+          endpoint_or_event: 'triage.guardrail.blocked',
+          correlation_id: correlationId,
+          user_id: user.userId,
+          role: user.role,
+          specialty: triageSession.specialty,
+          triage_session_id: triageSession._id.toString(),
+          violations: guardrailResult.violations,
+        }),
+      );
+    }
+    aiSummary = guardrailApplied ? undefined : aiSummary;
+
+    const priority = this.resolveFinalPriority(basePriority, redFlags);
+    const analysisDurationMs = Date.now() - startedAt;
+
+    if (analysisDurationMs > 15_000) {
+      this.logger.warn(
+        `Triage analysis exceeded SLO: ${analysisDurationMs}ms | correlation_id=${correlationId}`,
+      );
+    }
+
+    triageSession.analysis = {
+      priority,
+      redFlags,
+      aiSummary,
+      analysisDurationMs,
+      guardrailApplied,
+    };
+    triageSession.status = 'COMPLETED';
+    triageSession.completedAt = new Date();
+    await triageSession.save();
+
+    await this.consultationsService.createFromTriage({
+      patientId: triageSession.patientId,
+      triageSessionId: triageSession._id,
+      specialty: triageSession.specialty,
+      priority,
+    });
+
+    this.logger.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: 'info',
+        service: 'api',
+        endpoint_or_event: 'triage.analyze.completed',
+        correlation_id: correlationId,
+        user_id: user.userId,
+        role: user.role,
+        specialty: triageSession.specialty,
+        triage_session_id: triageSession._id.toString(),
+        priority,
+        red_flags_count: redFlags.length,
+        guardrail_applied: guardrailApplied,
+        latency_ms: analysisDurationMs,
+      }),
+    );
+
+    return {
+      sessionId: triageSession._id.toString(),
+      priority,
+      redFlags,
+      message:
+        priority === 'HIGH'
+          ? 'Se detectaron signos de alarma. Tu caso fue priorizado para atencion medica.'
+          : 'Analisis de triage completado. Tu caso fue enviado a la cola medica.',
+      highPriorityAlert: priority === 'HIGH',
+    };
+  }
+
+  private async getOwnedInProgressSession(
+    sessionId: string,
+    user: RequestUser,
+  ): Promise<TriageSessionDocument> {
+    if (!Types.ObjectId.isValid(sessionId)) {
+      throw new NotFoundException('Sesion de triage no encontrada');
+    }
+
+    if (!Types.ObjectId.isValid(user.userId)) {
+      throw new BadRequestException('patientId invalido');
+    }
+
+    const triageSession = await this.triageSessionModel
+      .findOne({
+        _id: new Types.ObjectId(sessionId),
+        patientId: new Types.ObjectId(user.userId),
+      })
+      .exec();
+
+    if (!triageSession) {
+      throw new NotFoundException('Sesion de triage no encontrada');
+    }
+
+    if (triageSession.status !== 'IN_PROGRESS') {
+      throw new BadRequestException('La sesion de triage no esta en progreso');
+    }
+
+    return triageSession;
+  }
+
+  private isSessionComplete(triageSession: TriageSessionDocument): boolean {
+    const requiredQuestionIds =
+      this.triageQuestionsRepository.getRequiredQuestionIds(
+        triageSession.specialty,
+      );
+    const answeredQuestionIds = new Set(
+      triageSession.answers.map((answer) => answer.questionId),
+    );
+
+    return requiredQuestionIds.every((questionId) =>
+      answeredQuestionIds.has(questionId),
+    );
+  }
+
+  private buildProgressState(
+    specialty: Specialty,
+    answeredQuestionIds: Set<string>,
+  ): {
+    totalQuestions: number;
+    answeredCount: number;
+    remainingQuestions: number;
+    progressPercent: number;
+    nextQuestionId: string | null;
+    isComplete: boolean;
+  } {
+    const requiredQuestionIds =
+      this.triageQuestionsRepository.getRequiredQuestionIds(specialty);
+    const totalQuestions = requiredQuestionIds.length;
+    const answeredCount = requiredQuestionIds.filter((questionId) =>
+      answeredQuestionIds.has(questionId),
+    ).length;
+    const remainingQuestions = Math.max(totalQuestions - answeredCount, 0);
+    const progressPercent =
+      totalQuestions === 0
+        ? 0
+        : Math.round((answeredCount / totalQuestions) * 100);
+    const nextQuestionId =
+      requiredQuestionIds.find(
+        (questionId) => !answeredQuestionIds.has(questionId),
+      ) ?? null;
+
+    return {
+      totalQuestions,
+      answeredCount,
+      remainingQuestions,
+      progressPercent,
+      nextQuestionId,
+      isComplete: remainingQuestions === 0,
+    };
+  }
+
+  private getRuleBasedBasePriority(redFlags: RedFlag[]): TriagePriority {
+    if (redFlags.some((flag) => flag.severity === 'CRITICAL')) {
+      return 'HIGH';
+    }
+
+    if (redFlags.some((flag) => flag.severity === 'WARNING')) {
+      return 'MODERATE';
+    }
+
+    return 'LOW';
+  }
+
+  private resolveFinalPriority(
+    basePriority: TriagePriority,
+    redFlags: RedFlag[],
+  ): TriagePriority {
+    if (redFlags.some((flag) => flag.severity === 'CRITICAL')) {
+      return 'HIGH';
+    }
+
+    if (
+      redFlags.some((flag) => flag.severity === 'WARNING') &&
+      basePriority === 'LOW'
+    ) {
+      return 'MODERATE';
+    }
+
+    return basePriority;
+  }
+}

--- a/src/triage/triage.service.ts
+++ b/src/triage/triage.service.ts
@@ -54,6 +54,22 @@ type ActiveTriageSessionResponse = {
   updatedAt: string | null;
 };
 
+type TriageSessionDetailResponse = {
+  id: string;
+  sessionId: string;
+  specialty: Specialty;
+  status: TriageSessionStatus;
+  isComplete: boolean;
+  currentQuestionId: string | null;
+  currentStep: number;
+  totalSteps: number;
+  totalQuestions: number;
+  nextQuestionId: string | null;
+  questions: TriageQuestion[];
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
 type ListActiveTriageSessionsResponse = {
   items: ActiveTriageSessionResponse[];
   total: number;
@@ -84,7 +100,18 @@ type AnalyzeTriageSessionResponse = {
   redFlags: RedFlag[];
   message: string;
   highPriorityAlert: boolean;
+  analysisMode?: 'AI_ASSISTED' | 'RULE_BASED';
+  noticeCode?:
+    | 'IA_TEMPORARILY_UNAVAILABLE_RULE_BASED_FALLBACK'
+    | 'IA_NOT_IMPLEMENTED_RULE_BASED_FALLBACK';
 };
+
+const TRIAGE_ANALYSIS_ERROR_CODES = {
+  DEPENDENCY_UNAVAILABLE: 'TRIAGE_ANALYSIS_DEPENDENCY_UNAVAILABLE',
+  RULESET_MISSING: 'TRIAGE_ANALYSIS_RULESET_MISSING',
+} as const;
+
+const TRIAGE_ANALYSIS_AI_RETRY_BACKOFF_MS = [150, 400] as const;
 
 @Injectable()
 export class TriageService {
@@ -208,6 +235,15 @@ export class TriageService {
       items,
       total: items.length,
     };
+  }
+
+  async getSessionDetail(
+    sessionId: string,
+    user: RequestUser,
+  ): Promise<TriageSessionDetailResponse> {
+    const triageSession = await this.getOwnedSession(sessionId, user);
+
+    return this.toSessionDetailResponse(triageSession);
   }
 
   async cancelSession(
@@ -368,6 +404,42 @@ export class TriageService {
   ): Promise<AnalyzeTriageSessionResponse> {
     const triageSession = await this.getOwnedInProgressSession(sessionId, user);
 
+    const requiredQuestionIds =
+      this.triageQuestionsRepository.getRequiredQuestionIds(
+        triageSession.specialty,
+      );
+
+    if (requiredQuestionIds.length === 0) {
+      const analysisDurationMs = 0;
+      triageSession.status = 'FAILED';
+      await triageSession.save();
+
+      this.logger.error(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: 'error',
+          service: 'api',
+          endpoint_or_event: 'triage.analyze.ruleset_missing',
+          correlation_id: correlationId,
+          user_id: user.userId,
+          role: user.role,
+          specialty: triageSession.specialty,
+          session_id: triageSession._id.toString(),
+          triage_session_id: triageSession._id.toString(),
+          latency_ms: analysisDurationMs,
+          error_code: TRIAGE_ANALYSIS_ERROR_CODES.RULESET_MISSING,
+        }),
+      );
+
+      throw new ServiceUnavailableException({
+        error: 'TriageAnalysisRulesetMissing',
+        errorCode: TRIAGE_ANALYSIS_ERROR_CODES.RULESET_MISSING,
+        specialty: triageSession.specialty,
+        sessionId: triageSession._id.toString(),
+        message: 'No fue posible completar el analisis de triage en este momento',
+      });
+    }
+
     if (!this.isSessionComplete(triageSession)) {
       throw new UnprocessableEntityException(
         'La sesion de triage no esta completa',
@@ -382,22 +454,33 @@ export class TriageService {
 
     let basePriority = this.getRuleBasedBasePriority(redFlags);
     let aiSummary: string | undefined;
+    let aiStrategy:
+      | 'provider'
+      | 'fallback_rule_based'
+      | 'fallback_rule_based_no_ai'
+      | 'not_applicable' = 'not_applicable';
+    let aiAttempts = 0;
 
     if (triageSession.specialty === Specialty.GENERAL_MEDICINE) {
       try {
-        const aiResult = await this.geminiTriageService.analyzeTriage(
+        const aiResult = await this.analyzeGeneralMedicineWithResilience(
           triageSession.answers,
           redFlags,
           user,
           correlationId,
+          triageSession._id.toString(),
         );
 
         basePriority = aiResult.basePriority;
         aiSummary = aiResult.aiSummary;
+        aiStrategy = aiResult.strategy;
+        aiAttempts = aiResult.attempts;
       } catch (error: unknown) {
         const analysisDurationMs = Date.now() - startedAt;
         triageSession.status = 'FAILED';
         await triageSession.save();
+
+        const normalizedError = this.normalizeError(error);
 
         this.logger.error(
           JSON.stringify({
@@ -409,16 +492,23 @@ export class TriageService {
             user_id: user.userId,
             role: user.role,
             specialty: triageSession.specialty,
+            session_id: triageSession._id.toString(),
             triage_session_id: triageSession._id.toString(),
             latency_ms: analysisDurationMs,
-            error_message:
-              error instanceof Error ? error.message : String(error),
+            error_code: TRIAGE_ANALYSIS_ERROR_CODES.DEPENDENCY_UNAVAILABLE,
+            error_name: normalizedError.name,
+            error_message: normalizedError.message,
+            error_stack: normalizedError.stack,
           }),
         );
 
-        throw new ServiceUnavailableException(
-          'No fue posible completar el analisis de triage en este momento',
-        );
+        throw new ServiceUnavailableException({
+          error: 'TriageAnalysisDependencyUnavailable',
+          errorCode: TRIAGE_ANALYSIS_ERROR_CODES.DEPENDENCY_UNAVAILABLE,
+          specialty: triageSession.specialty,
+          sessionId: triageSession._id.toString(),
+          message: 'No fue posible completar el analisis de triage en este momento',
+        });
       }
     }
 
@@ -479,24 +569,215 @@ export class TriageService {
         user_id: user.userId,
         role: user.role,
         specialty: triageSession.specialty,
+        session_id: triageSession._id.toString(),
         triage_session_id: triageSession._id.toString(),
         priority,
         red_flags_count: redFlags.length,
+        ai_strategy: aiStrategy,
+        ai_attempts: aiAttempts,
         guardrail_applied: guardrailApplied,
         latency_ms: analysisDurationMs,
       }),
     );
 
+    let message =
+      priority === 'HIGH'
+        ? 'Se detectaron signos de alarma. Tu caso fue priorizado para atencion medica.'
+        : 'Analisis de triage completado. Tu caso fue enviado a la cola medica.';
+    let noticeCode: AnalyzeTriageSessionResponse['noticeCode'];
+
+    if (aiStrategy === 'fallback_rule_based') {
+      message =
+        priority === 'HIGH'
+          ? 'Se detectaron signos de alarma. Tu caso fue priorizado para atencion medica. Se aplico analisis por reglas clinicas por indisponibilidad temporal de IA.'
+          : 'Analisis de triage completado con reglas clinicas por indisponibilidad temporal de IA. Tu caso fue enviado a la cola medica.';
+      noticeCode = 'IA_TEMPORARILY_UNAVAILABLE_RULE_BASED_FALLBACK';
+    }
+
+    if (aiStrategy === 'fallback_rule_based_no_ai') {
+      message =
+        priority === 'HIGH'
+          ? 'Se detectaron signos de alarma. Tu caso fue priorizado para atencion medica. Analisis realizado con reglas clinicas porque la IA no esta implementada en este entorno.'
+          : 'Analisis de triage completado con reglas clinicas porque la IA no esta implementada en este entorno. Tu caso fue enviado a la cola medica.';
+      noticeCode = 'IA_NOT_IMPLEMENTED_RULE_BASED_FALLBACK';
+    }
+
     return {
       sessionId: triageSession._id.toString(),
       priority,
       redFlags,
-      message:
-        priority === 'HIGH'
-          ? 'Se detectaron signos de alarma. Tu caso fue priorizado para atencion medica.'
-          : 'Analisis de triage completado. Tu caso fue enviado a la cola medica.',
+      message,
       highPriorityAlert: priority === 'HIGH',
+      analysisMode: aiStrategy === 'provider' ? 'AI_ASSISTED' : 'RULE_BASED',
+      noticeCode,
     };
+  }
+
+  private async analyzeGeneralMedicineWithResilience(
+    answers: { questionId: string; questionText: string; answerValue: unknown }[],
+    redFlags: RedFlag[],
+    user: RequestUser,
+    correlationId: string | undefined,
+    sessionId: string,
+  ): Promise<{
+    basePriority: TriagePriority;
+    aiSummary?: string;
+    strategy: 'provider' | 'fallback_rule_based' | 'fallback_rule_based_no_ai';
+    attempts: number;
+  }> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= TRIAGE_ANALYSIS_AI_RETRY_BACKOFF_MS.length + 1; attempt += 1) {
+      try {
+        const aiResult = await this.geminiTriageService.analyzeTriage(
+          answers,
+          redFlags,
+          user,
+          correlationId,
+        );
+
+        return {
+          basePriority: aiResult.basePriority,
+          aiSummary: aiResult.aiSummary,
+          strategy: 'provider',
+          attempts: attempt,
+        };
+      } catch (error: unknown) {
+        lastError = error;
+
+        const shouldRetry =
+          attempt <= TRIAGE_ANALYSIS_AI_RETRY_BACKOFF_MS.length &&
+          this.isTransientAiError(error);
+
+        if (shouldRetry) {
+          const backoffMs = TRIAGE_ANALYSIS_AI_RETRY_BACKOFF_MS[attempt - 1];
+          const normalizedError = this.normalizeError(error);
+
+          this.logger.warn(
+            JSON.stringify({
+              timestamp: new Date().toISOString(),
+              level: 'warn',
+              service: 'api',
+              endpoint_or_event: 'triage.analyze.retry',
+              correlation_id: correlationId,
+              user_id: user.userId,
+              role: user.role,
+              specialty: Specialty.GENERAL_MEDICINE,
+              session_id: sessionId,
+              triage_session_id: sessionId,
+              attempt,
+              backoff_ms: backoffMs,
+              error_name: normalizedError.name,
+              error_message: normalizedError.message,
+            }),
+          );
+
+          await this.wait(backoffMs);
+          continue;
+        }
+
+        break;
+      }
+    }
+
+    if (
+      lastError &&
+      (this.isTransientAiError(lastError) ||
+        this.isAiUnavailableByDesign(lastError))
+    ) {
+      const fallbackPriority = this.getRuleBasedBasePriority(redFlags);
+      const normalizedError = this.normalizeError(lastError);
+      const fallbackForNoAi = this.isAiUnavailableByDesign(lastError);
+
+      this.logger.warn(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: 'warn',
+          service: 'api',
+          endpoint_or_event: 'triage.analyze.fallback_applied',
+          correlation_id: correlationId,
+          user_id: user.userId,
+          role: user.role,
+          specialty: Specialty.GENERAL_MEDICINE,
+          session_id: sessionId,
+          triage_session_id: sessionId,
+          attempts: TRIAGE_ANALYSIS_AI_RETRY_BACKOFF_MS.length + 1,
+          fallback_mode: fallbackForNoAi
+            ? 'IA_NOT_IMPLEMENTED'
+            : 'TEMPORARY_UNAVAILABLE',
+          fallback_priority: fallbackPriority,
+          reason: normalizedError.message,
+        }),
+      );
+
+      return {
+        basePriority: fallbackPriority,
+        aiSummary: undefined,
+        strategy: fallbackForNoAi
+          ? 'fallback_rule_based_no_ai'
+          : 'fallback_rule_based',
+        attempts: TRIAGE_ANALYSIS_AI_RETRY_BACKOFF_MS.length + 1,
+      };
+    }
+
+    throw lastError;
+  }
+
+  private isTransientAiError(error: unknown): boolean {
+    const normalizedError = this.normalizeError(error);
+    const signal = `${normalizedError.name} ${normalizedError.message}`.toLowerCase();
+
+    return [
+      'timeout',
+      'timed out',
+      'etimedout',
+      'econnreset',
+      'econnrefused',
+      'network',
+      'socket hang up',
+      '429',
+      'rate limit',
+      'unavailable',
+      'temporarily',
+      'gateway',
+    ].some((keyword) => signal.includes(keyword));
+  }
+
+  private isAiUnavailableByDesign(error: unknown): boolean {
+    const normalizedError = this.normalizeError(error);
+    const signal = `${normalizedError.name} ${normalizedError.message}`.toLowerCase();
+
+    return [
+      'ai provider is disabled',
+      'provider configuration is incomplete',
+      'gemini_api_key',
+      'api key',
+      'ai is disabled',
+      'not implemented',
+    ].some((keyword) => signal.includes(keyword));
+  }
+
+  private normalizeError(error: unknown): {
+    name: string;
+    message: string;
+    stack?: string;
+  } {
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      };
+    }
+
+    return {
+      name: 'UnknownError',
+      message: String(error),
+    };
+  }
+
+  private async wait(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   private async getOwnedInProgressSession(
@@ -548,14 +829,7 @@ export class TriageService {
       triageSession.specialty,
       answeredQuestionIds,
     );
-    const nextStepIncrement = progress.isComplete ? 0 : 1;
-    const currentStep =
-      progress.totalQuestions === 0
-        ? 0
-        : Math.min(
-            progress.answeredCount + nextStepIncrement,
-            progress.totalQuestions,
-          );
+    const currentStep = this.buildCurrentStep(progress);
 
     return {
       id: triageSession._id.toString(),
@@ -568,6 +842,52 @@ export class TriageService {
       createdAt: triageSession.createdAt?.toISOString() ?? null,
       updatedAt: triageSession.updatedAt?.toISOString() ?? null,
     };
+  }
+
+  private toSessionDetailResponse(
+    triageSession: TriageSessionDocument,
+  ): TriageSessionDetailResponse {
+    const answeredQuestionIds = new Set(
+      triageSession.answers.map((answer) => answer.questionId),
+    );
+    const progress = this.buildProgressState(
+      triageSession.specialty,
+      answeredQuestionIds,
+    );
+    const sessionId = triageSession._id.toString();
+
+    return {
+      id: sessionId,
+      sessionId,
+      specialty: triageSession.specialty,
+      status: triageSession.status,
+      isComplete: progress.isComplete,
+      currentQuestionId: progress.nextQuestionId,
+      currentStep: this.buildCurrentStep(progress),
+      totalSteps: progress.totalQuestions,
+      totalQuestions: progress.totalQuestions,
+      nextQuestionId: progress.nextQuestionId,
+      questions: this.triageQuestionsRepository.getQuestionsBySpecialty(
+        triageSession.specialty,
+      ),
+      createdAt: triageSession.createdAt?.toISOString() ?? null,
+      updatedAt: triageSession.updatedAt?.toISOString() ?? null,
+    };
+  }
+
+  private buildCurrentStep(progress: {
+    totalQuestions: number;
+    answeredCount: number;
+    isComplete: boolean;
+  }): number {
+    const nextStepIncrement = progress.isComplete ? 0 : 1;
+
+    return progress.totalQuestions === 0
+      ? 0
+      : Math.min(
+          progress.answeredCount + nextStepIncrement,
+          progress.totalQuestions,
+        );
   }
 
   private async findActiveSessionByPatientAndSpecialty(

--- a/src/triage/triage.service.ts
+++ b/src/triage/triage.service.ts
@@ -22,6 +22,7 @@ import {
   TriagePriority,
   TriageSession,
   TriageSessionDocument,
+  TriageSessionStatus,
 } from './schemas/triage-session.schema';
 import {
   TriageQuestion,
@@ -30,8 +31,8 @@ import {
 
 type CreateTriageSessionResponse = {
   sessionId: string;
-  specialty: string;
-  status: string;
+  specialty: Specialty;
+  status: TriageSessionStatus;
   questions: TriageQuestion[];
   totalQuestions: number;
   answeredCount: number;
@@ -39,6 +40,31 @@ type CreateTriageSessionResponse = {
   progressPercent: number;
   nextQuestionId: string | null;
   isComplete: boolean;
+};
+
+type ActiveTriageSessionResponse = {
+  id: string;
+  specialty: Specialty;
+  status: TriageSessionStatus;
+  currentStep: number;
+  totalSteps: number;
+  currentQuestionId: string | null;
+  isComplete: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+type ListActiveTriageSessionsResponse = {
+  items: ActiveTriageSessionResponse[];
+  total: number;
+};
+
+type CancelTriageSessionResponse = {
+  sessionId: string;
+  specialty: Specialty;
+  status: TriageSessionStatus;
+  canceledAt: string;
+  message: string;
 };
 
 type SaveTriageAnswersResponse = {
@@ -83,29 +109,45 @@ export class TriageService {
     }
 
     const patientId = new Types.ObjectId(user.userId);
-    const existingSession = await this.triageSessionModel
-      .findOne({
-        patientId,
-        specialty: dto.specialty,
-        status: 'IN_PROGRESS',
-      })
-      .select('_id')
-      .lean()
-      .exec();
+    const existingSession = await this.findActiveSessionByPatientAndSpecialty(
+      patientId,
+      dto.specialty,
+    );
 
     if (existingSession) {
-      throw new ConflictException(
-        'Ya existe una sesion de triage en progreso para esta especialidad',
+      throw this.buildSessionInProgressConflict(
+        dto.specialty,
+        existingSession._id.toString(),
       );
     }
 
-    const [createdSession] = await this.triageSessionModel.create([
-      {
-        patientId,
-        specialty: dto.specialty,
-        status: 'IN_PROGRESS',
-      },
-    ]);
+    let createdSession: TriageSessionDocument;
+    try {
+      [createdSession] = await this.triageSessionModel.create([
+        {
+          patientId,
+          specialty: dto.specialty,
+          status: 'IN_PROGRESS',
+        },
+      ]);
+    } catch (error: unknown) {
+      if (this.isMongoDuplicateKeyError(error)) {
+        const duplicatedSession =
+          await this.findActiveSessionByPatientAndSpecialty(
+            patientId,
+            dto.specialty,
+          );
+
+        if (duplicatedSession) {
+          throw this.buildSessionInProgressConflict(
+            dto.specialty,
+            duplicatedSession._id.toString(),
+          );
+        }
+      }
+
+      throw error;
+    }
 
     const questions = this.triageQuestionsRepository.getQuestionsBySpecialty(
       dto.specialty,
@@ -137,6 +179,73 @@ export class TriageService {
       progressPercent: progress.progressPercent,
       nextQuestionId: progress.nextQuestionId,
       isComplete: progress.isComplete,
+    };
+  }
+
+  async getActiveSessions(
+    user: RequestUser,
+    specialty?: Specialty,
+  ): Promise<ListActiveTriageSessionsResponse> {
+    if (!Types.ObjectId.isValid(user.userId)) {
+      throw new BadRequestException('patientId invalido');
+    }
+
+    const patientId = new Types.ObjectId(user.userId);
+    const query = {
+      patientId,
+      status: 'IN_PROGRESS',
+      ...(specialty ? { specialty } : {}),
+    };
+
+    const sessions = await this.triageSessionModel
+      .find(query)
+      .sort({ createdAt: -1 })
+      .exec();
+
+    const items = sessions.map((session) => this.toActiveSessionSummary(session));
+
+    return {
+      items,
+      total: items.length,
+    };
+  }
+
+  async cancelSession(
+    sessionId: string,
+    user: RequestUser,
+    correlationId?: string,
+  ): Promise<CancelTriageSessionResponse> {
+    const triageSession = await this.getOwnedSession(sessionId, user);
+
+    if (triageSession.status !== 'IN_PROGRESS') {
+      throw new BadRequestException('Solo se pueden cancelar sesiones en progreso');
+    }
+
+    const canceledAt = new Date();
+    triageSession.status = 'CANCELED';
+    triageSession.canceledAt = canceledAt;
+    await triageSession.save();
+
+    this.logger.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: 'info',
+        service: 'api',
+        endpoint_or_event: 'triage.session.canceled',
+        correlation_id: correlationId,
+        user_id: user.userId,
+        role: user.role,
+        specialty: triageSession.specialty,
+        triage_session_id: triageSession._id.toString(),
+      }),
+    );
+
+    return {
+      sessionId: triageSession._id.toString(),
+      specialty: triageSession.specialty,
+      status: triageSession.status,
+      canceledAt: canceledAt.toISOString(),
+      message: 'Sesion de triage cancelada correctamente',
     };
   }
 
@@ -394,6 +503,19 @@ export class TriageService {
     sessionId: string,
     user: RequestUser,
   ): Promise<TriageSessionDocument> {
+    const triageSession = await this.getOwnedSession(sessionId, user);
+
+    if (triageSession.status !== 'IN_PROGRESS') {
+      throw new BadRequestException('La sesion de triage no esta en progreso');
+    }
+
+    return triageSession;
+  }
+
+  private async getOwnedSession(
+    sessionId: string,
+    user: RequestUser,
+  ): Promise<TriageSessionDocument> {
     if (!Types.ObjectId.isValid(sessionId)) {
       throw new NotFoundException('Sesion de triage no encontrada');
     }
@@ -413,11 +535,77 @@ export class TriageService {
       throw new NotFoundException('Sesion de triage no encontrada');
     }
 
-    if (triageSession.status !== 'IN_PROGRESS') {
-      throw new BadRequestException('La sesion de triage no esta en progreso');
-    }
-
     return triageSession;
+  }
+
+  private toActiveSessionSummary(
+    triageSession: TriageSessionDocument,
+  ): ActiveTriageSessionResponse {
+    const answeredQuestionIds = new Set(
+      triageSession.answers.map((answer) => answer.questionId),
+    );
+    const progress = this.buildProgressState(
+      triageSession.specialty,
+      answeredQuestionIds,
+    );
+    const nextStepIncrement = progress.isComplete ? 0 : 1;
+    const currentStep =
+      progress.totalQuestions === 0
+        ? 0
+        : Math.min(
+            progress.answeredCount + nextStepIncrement,
+            progress.totalQuestions,
+          );
+
+    return {
+      id: triageSession._id.toString(),
+      specialty: triageSession.specialty,
+      status: triageSession.status,
+      currentStep,
+      totalSteps: progress.totalQuestions,
+      currentQuestionId: progress.nextQuestionId,
+      isComplete: progress.isComplete,
+      createdAt: triageSession.createdAt?.toISOString() ?? null,
+      updatedAt: triageSession.updatedAt?.toISOString() ?? null,
+    };
+  }
+
+  private async findActiveSessionByPatientAndSpecialty(
+    patientId: Types.ObjectId,
+    specialty: Specialty,
+  ): Promise<{ _id: Types.ObjectId } | null> {
+    return this.triageSessionModel
+      .findOne({
+        patientId,
+        specialty,
+        status: 'IN_PROGRESS',
+      })
+      .select('_id')
+      .lean()
+      .exec();
+  }
+
+  private buildSessionInProgressConflict(
+    specialty: Specialty,
+    existingSessionId: string,
+  ): ConflictException {
+    return new ConflictException({
+      error: 'TriageSessionInProgress',
+      errorCode: 'TRIAGE_SESSION_IN_PROGRESS',
+      specialty,
+      existingSessionId,
+      status: 'IN_PROGRESS',
+      message: 'Ya existe una sesion de triage en progreso para esta especialidad',
+    });
+  }
+
+  private isMongoDuplicateKeyError(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: unknown }).code === 11000
+    );
   }
 
   private isSessionComplete(triageSession: TriageSessionDocument): boolean {

--- a/test/e1.e2e-spec.ts
+++ b/test/e1.e2e-spec.ts
@@ -202,6 +202,10 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
     redFlags: unknown[];
     message: string;
     highPriorityAlert: boolean;
+    analysisMode?: 'AI_ASSISTED' | 'RULE_BASED';
+    noticeCode?:
+      | 'IA_TEMPORARILY_UNAVAILABLE_RULE_BASED_FALLBACK'
+      | 'IA_NOT_IMPLEMENTED_RULE_BASED_FALLBACK';
   };
 
   async function login(
@@ -1060,7 +1064,7 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
       .expect(422);
   });
 
-  it('POST /v1/triage/sessions/:sessionId/analyze should mark FAILED and return 503 when AI fails', async () => {
+  it('POST /v1/triage/sessions/:sessionId/analyze should fallback to RULE_BASED when AI is disabled in environment', async () => {
     await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
       firstName: 'Laura',
       lastName: 'Saenz',
@@ -1095,24 +1099,31 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
       })
       .expect(200);
 
-    await request(app.getHttpServer())
+    const analyzeResponse = await request(app.getHttpServer())
       .post(`/v1/triage/sessions/${createBody.sessionId}/analyze`)
       .set('Authorization', `Bearer ${patientToken}`)
-      .expect(503);
+      .expect(200);
+
+    const analyzeBody =
+      analyzeResponse.body as AnalyzeTriageSessionResponseBody;
+    expect(analyzeBody.analysisMode).toBe('RULE_BASED');
+    expect(analyzeBody.noticeCode).toBe(
+      'IA_NOT_IMPLEMENTED_RULE_BASED_FALLBACK',
+    );
 
     const triageSession = await triageSessionModel
       .findById(createBody.sessionId)
       .lean()
       .exec();
 
-    expect(triageSession?.status).toBe('FAILED');
+    expect(triageSession?.status).toBe('COMPLETED');
 
     const consultation = await consultationModel
       .findOne({ triageSessionId: new Types.ObjectId(createBody.sessionId) })
       .lean()
       .exec();
 
-    expect(consultation).toBeNull();
+    expect(consultation).toBeDefined();
   });
 
   it('POST /v1/triage/sessions/:sessionId/analyze should complete session and create consultation', async () => {

--- a/test/e1.e2e-spec.ts
+++ b/test/e1.e2e-spec.ts
@@ -22,6 +22,14 @@ import {
   Patient,
   PatientDocument,
 } from '../src/patients/schemas/patient.schema';
+import {
+  TriageSession,
+  TriageSessionDocument,
+} from '../src/triage/schemas/triage-session.schema';
+import {
+  Consultation,
+  ConsultationDocument,
+} from '../src/consultations/schemas/consultation.schema';
 import { DoctorStatus } from '../src/common/enums/doctor-status.enum';
 import { RethusState } from '../src/common/enums/rethus-state.enum';
 
@@ -51,6 +59,8 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
   let doctorModel: Model<DoctorDocument>;
   let rethusVerificationModel: Model<RethusVerificationDocument>;
   let notificationModel: Model<NotificationDocument>;
+  let triageSessionModel: Model<TriageSessionDocument>;
+  let consultationModel: Model<ConsultationDocument>;
 
   const adminEmail = 'admin@example.com';
   const adminPassword = 'AdminP@ss1';
@@ -156,6 +166,41 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
     errorRate: number;
     source: string;
     degraded: boolean;
+  };
+
+  type CreateTriageSessionResponseBody = {
+    sessionId: string;
+    specialty: string;
+    status: string;
+    totalQuestions: number;
+    answeredCount: number;
+    remainingQuestions: number;
+    progressPercent: number;
+    nextQuestionId: string | null;
+    isComplete: boolean;
+    questions: Array<{
+      questionId: string;
+      questionText: string;
+    }>;
+  };
+
+  type SaveTriageAnswersResponseBody = {
+    sessionId: string;
+    answersCount: number;
+    isComplete: boolean;
+    totalQuestions: number;
+    answeredCount: number;
+    remainingQuestions: number;
+    progressPercent: number;
+    nextQuestionId: string | null;
+  };
+
+  type AnalyzeTriageSessionResponseBody = {
+    sessionId: string;
+    priority: string;
+    redFlags: unknown[];
+    message: string;
+    highPriorityAlert: boolean;
   };
 
   async function login(
@@ -295,6 +340,12 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
     notificationModel = app.get<Model<NotificationDocument>>(
       getModelToken(Notification.name),
     );
+    triageSessionModel = app.get<Model<TriageSessionDocument>>(
+      getModelToken(TriageSession.name),
+    );
+    consultationModel = app.get<Model<ConsultationDocument>>(
+      getModelToken(Consultation.name),
+    );
   });
 
   beforeEach(async () => {
@@ -304,6 +355,8 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
       doctorModel.deleteMany({}),
       rethusVerificationModel.deleteMany({}),
       notificationModel.deleteMany({}),
+      triageSessionModel.deleteMany({}),
+      consultationModel.deleteMany({}),
     ]);
 
     const passwordHash = await bcrypt.hash(adminPassword, 12);
@@ -671,6 +724,460 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
       .get('/v1/consultations/queue')
       .set('Authorization', `Bearer ${doctorToken}`)
       .expect(403);
+  });
+
+  it('POST /v1/triage/sessions should create a triage session for patient role', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Sofia',
+      lastName: 'Mendez',
+      email: 'triage-patient@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const patientToken = await login(
+      'triage-patient@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const response = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const body = response.body as CreateTriageSessionResponseBody;
+    expect(body.sessionId).toBeDefined();
+    expect(body.specialty).toBe('GENERAL_MEDICINE');
+    expect(body.status).toBe('IN_PROGRESS');
+    expect(body.totalQuestions).toBeGreaterThan(0);
+    expect(body.answeredCount).toBe(0);
+    expect(body.progressPercent).toBe(0);
+    expect(body.isComplete).toBe(false);
+    expect(Array.isArray(body.questions)).toBe(true);
+    expect(body.questions.length).toBeGreaterThan(0);
+    expect(typeof body.questions[0]?.questionId).toBe('string');
+    expect(typeof body.questions[0]?.questionText).toBe('string');
+  });
+
+  it('POST /v1/triage/sessions should return 409 when an active session already exists', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Paula',
+      lastName: 'Rios',
+      email: 'triage-conflict@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const patientToken = await login(
+      'triage-conflict@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(409);
+  });
+
+  it('POST /v1/triage/sessions should return 400 for invalid specialty', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Nora',
+      lastName: 'Diaz',
+      email: 'triage-invalid-specialty@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const patientToken = await login(
+      'triage-invalid-specialty@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'DENTISTRY' })
+      .expect(400);
+  });
+
+  it('POST /v1/triage/sessions should return 401 without token', async () => {
+    await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(401);
+  });
+
+  it('POST /v1/triage/sessions should return 403 for non-patient roles', async () => {
+    const adminToken = await login(adminEmail, adminPassword, 'staff');
+
+    await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(403);
+  });
+
+  it('POST /v1/triage/sessions/:sessionId/answers should save partial answers and return isComplete false', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Rosa',
+      lastName: 'Perez',
+      email: 'triage-answers-partial@example.com',
+      password: 'StrongP@ss1',
+    });
+    const patientToken = await login(
+      'triage-answers-partial@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const createResponse = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const createBody = createResponse.body as CreateTriageSessionResponseBody;
+
+    const saveResponse = await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/answers`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({
+        answers: [{ questionId: 'MG-Q1', answerValue: 'dolor de cabeza' }],
+      })
+      .expect(200);
+
+    const saveBody = saveResponse.body as SaveTriageAnswersResponseBody;
+    expect(saveBody).toMatchObject({
+      sessionId: createBody.sessionId,
+      answersCount: 1,
+      isComplete: false,
+      totalQuestions: 5,
+      answeredCount: 1,
+      remainingQuestions: 4,
+      progressPercent: 20,
+      nextQuestionId: 'MG-Q2',
+    });
+  });
+
+  it('POST /v1/triage/sessions/:sessionId/answers should return isComplete true when all questions are answered', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Marta',
+      lastName: 'Lopez',
+      email: 'triage-answers-complete@example.com',
+      password: 'StrongP@ss1',
+    });
+    const patientToken = await login(
+      'triage-answers-complete@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const createResponse = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const createBody = createResponse.body as CreateTriageSessionResponseBody;
+
+    const saveResponse = await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/answers`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({
+        answers: [
+          { questionId: 'MG-Q1', answerValue: 'dolor de cabeza' },
+          { questionId: 'MG-Q2', answerValue: '2 dias' },
+          { questionId: 'MG-Q3', answerValue: 5 },
+          { questionId: 'MG-Q4', answerValue: 'no' },
+          { questionId: 'MG-Q5', answerValue: 'no' },
+        ],
+      })
+      .expect(200);
+
+    const saveBody = saveResponse.body as SaveTriageAnswersResponseBody;
+    expect(saveBody).toMatchObject({
+      sessionId: createBody.sessionId,
+      answersCount: 5,
+      isComplete: true,
+      totalQuestions: 5,
+      answeredCount: 5,
+      remainingQuestions: 0,
+      progressPercent: 100,
+      nextQuestionId: null,
+    });
+  });
+
+  it('POST /v1/triage/sessions/:sessionId/answers should return 404 for non-owned session', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Nadia',
+      lastName: 'Ruiz',
+      email: 'triage-owner-a@example.com',
+      password: 'StrongP@ss1',
+    });
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Julia',
+      lastName: 'Ruiz',
+      email: 'triage-owner-b@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const patientAToken = await login(
+      'triage-owner-a@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+    const patientBToken = await login(
+      'triage-owner-b@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const createResponse = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientAToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const createBody = createResponse.body as CreateTriageSessionResponseBody;
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/answers`)
+      .set('Authorization', `Bearer ${patientBToken}`)
+      .send({
+        answers: [{ questionId: 'MG-Q1', answerValue: 'dolor de cabeza' }],
+      })
+      .expect(404);
+  });
+
+  it('POST /v1/triage/sessions/:sessionId/answers should return 400 for invalid session status', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Clara',
+      lastName: 'Vega',
+      email: 'triage-invalid-status@example.com',
+      password: 'StrongP@ss1',
+    });
+    const patientToken = await login(
+      'triage-invalid-status@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const createResponse = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const createBody = createResponse.body as CreateTriageSessionResponseBody;
+
+    await triageSessionModel
+      .updateOne(
+        { _id: new Types.ObjectId(createBody.sessionId) },
+        { $set: { status: 'COMPLETED' } },
+      )
+      .exec();
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/answers`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({
+        answers: [{ questionId: 'MG-Q1', answerValue: 'dolor de cabeza' }],
+      })
+      .expect(400);
+  });
+
+  it('POST /v1/triage/sessions/:sessionId/answers should return 400 for invalid question ids', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Sandra',
+      lastName: 'Mora',
+      email: 'triage-invalid-question@example.com',
+      password: 'StrongP@ss1',
+    });
+    const patientToken = await login(
+      'triage-invalid-question@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const createResponse = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const createBody = createResponse.body as CreateTriageSessionResponseBody;
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/answers`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({
+        answers: [{ questionId: 'INVALID-Q', answerValue: 'x' }],
+      })
+      .expect(400);
+  });
+
+  it('POST /v1/triage/sessions/:sessionId/analyze should return 422 when session is incomplete', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Monica',
+      lastName: 'Gil',
+      email: 'triage-analyze-incomplete@example.com',
+      password: 'StrongP@ss1',
+    });
+    const patientToken = await login(
+      'triage-analyze-incomplete@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const createResponse = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'ODONTOLOGY' })
+      .expect(201);
+
+    const createBody = createResponse.body as CreateTriageSessionResponseBody;
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/analyze`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .expect(422);
+  });
+
+  it('POST /v1/triage/sessions/:sessionId/analyze should mark FAILED and return 503 when AI fails', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Laura',
+      lastName: 'Saenz',
+      email: 'triage-analyze-failed@example.com',
+      password: 'StrongP@ss1',
+    });
+    const patientToken = await login(
+      'triage-analyze-failed@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const createResponse = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const createBody = createResponse.body as CreateTriageSessionResponseBody;
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/answers`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({
+        answers: [
+          { questionId: 'MG-Q1', answerValue: 'dolor de cabeza' },
+          { questionId: 'MG-Q2', answerValue: '2 dias' },
+          { questionId: 'MG-Q3', answerValue: 5 },
+          { questionId: 'MG-Q4', answerValue: 'no' },
+          { questionId: 'MG-Q5', answerValue: 'no' },
+        ],
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/analyze`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .expect(503);
+
+    const triageSession = await triageSessionModel
+      .findById(createBody.sessionId)
+      .lean()
+      .exec();
+
+    expect(triageSession?.status).toBe('FAILED');
+
+    const consultation = await consultationModel
+      .findOne({ triageSessionId: new Types.ObjectId(createBody.sessionId) })
+      .lean()
+      .exec();
+
+    expect(consultation).toBeNull();
+  });
+
+  it('POST /v1/triage/sessions/:sessionId/analyze should complete session and create consultation', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Erika',
+      lastName: 'Nuñez',
+      email: 'triage-analyze-success@example.com',
+      password: 'StrongP@ss1',
+    });
+    const patientToken = await login(
+      'triage-analyze-success@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const createResponse = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ specialty: 'ODONTOLOGY' })
+      .expect(201);
+
+    const createBody = createResponse.body as CreateTriageSessionResponseBody;
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/answers`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({
+        answers: [
+          { questionId: 'OD-Q1', answerValue: 'muela superior derecha' },
+          { questionId: 'OD-Q2', answerValue: '3 dias' },
+          { questionId: 'OD-Q3', answerValue: 8 },
+          { questionId: 'OD-Q4', answerValue: 'si' },
+          { questionId: 'OD-Q5', answerValue: 'si' },
+        ],
+      })
+      .expect(200);
+
+    const analyzeResponse = await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${createBody.sessionId}/analyze`)
+      .set('Authorization', `Bearer ${patientToken}`)
+      .expect(200);
+
+    const analyzeBody =
+      analyzeResponse.body as AnalyzeTriageSessionResponseBody;
+
+    expect(analyzeBody).toMatchObject({
+      sessionId: createBody.sessionId,
+      priority: 'MODERATE',
+      highPriorityAlert: false,
+    });
+    expect(typeof analyzeBody.message).toBe('string');
+    expect(Array.isArray(analyzeBody.redFlags)).toBe(true);
+
+    const triageSession = await triageSessionModel
+      .findById(createBody.sessionId)
+      .lean()
+      .exec();
+
+    expect(triageSession?.status).toBe('COMPLETED');
+    expect(triageSession?.analysis?.priority).toBe('MODERATE');
+    expect(triageSession?.analysis?.analysisDurationMs).toBeGreaterThanOrEqual(
+      0,
+    );
+
+    const consultation = await consultationModel
+      .findOne({ triageSessionId: new Types.ObjectId(createBody.sessionId) })
+      .lean()
+      .exec();
+
+    expect(consultation).toMatchObject({
+      specialty: 'ODONTOLOGY',
+      priority: 'MODERATE',
+      status: 'PENDING',
+    });
   });
 
   it('GET /v1/consultations/queue should allow verified doctor', async () => {

--- a/test/triage-mg.e2e-spec.ts
+++ b/test/triage-mg.e2e-spec.ts
@@ -120,6 +120,37 @@ describe('HU-003 Triage MG (e2e)', () => {
     total: number;
   };
 
+  type TriageSessionDetailResponseBody = {
+    id: string;
+    sessionId: string;
+    specialty: string;
+    status: string;
+    isComplete: boolean;
+    currentQuestionId: string | null;
+    currentStep: number;
+    totalSteps: number;
+    totalQuestions: number;
+    nextQuestionId: string | null;
+    questions: Array<{
+      id: string;
+      questionId: string;
+      title: string;
+      questionText: string;
+      description?: string;
+      type: 'SINGLE_CHOICE' | 'MULTI_CHOICE' | 'NUMERIC_SCALE';
+      options?: Array<{
+        id: string;
+        label: string;
+        description?: string;
+      }>;
+      minValue?: number;
+      maxValue?: number;
+      step?: number;
+    }>;
+    createdAt: string;
+    updatedAt: string;
+  };
+
   type CancelTriageSessionResponseBody = {
     sessionId: string;
     specialty: string;
@@ -156,10 +187,17 @@ describe('HU-003 Triage MG (e2e)', () => {
   }
 
   async function createMgSession(token: string): Promise<string> {
+    return createSession(token, 'GENERAL_MEDICINE');
+  }
+
+  async function createSession(
+    token: string,
+    specialty: 'GENERAL_MEDICINE' | 'ODONTOLOGY',
+  ): Promise<string> {
     const response = await request(app.getHttpServer())
       .post('/v1/triage/sessions')
       .set('Authorization', `Bearer ${token}`)
-      .send({ specialty: 'GENERAL_MEDICINE' })
+      .send({ specialty })
       .expect(201);
 
     const body = response.body as CreateTriageSessionResponseBody;
@@ -180,6 +218,25 @@ describe('HU-003 Triage MG (e2e)', () => {
           { questionId: 'MG-Q3', answerValue: 4 },
           { questionId: 'MG-Q4', answerValue: 'no' },
           { questionId: 'MG-Q5', answerValue: 'no' },
+        ],
+      })
+      .expect(200);
+  }
+
+  async function completeOdAnswers(
+    token: string,
+    sessionId: string,
+  ): Promise<void> {
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/answers`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        answers: [
+          { questionId: 'OD-Q1', answerValue: 'parte superior' },
+          { questionId: 'OD-Q2', answerValue: '1 dia' },
+          { questionId: 'OD-Q3', answerValue: 6 },
+          { questionId: 'OD-Q4', answerValue: 'no' },
+          { questionId: 'OD-Q5', answerValue: 'si' },
         ],
       })
       .expect(200);
@@ -328,6 +385,74 @@ describe('HU-003 Triage MG (e2e)', () => {
     });
   });
 
+  it('GET /v1/triage/sessions/:id returns 200 for owner with full questionnaire metadata', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createMgSession(token);
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/answers`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ answers: [{ questionId: 'MG-Q1', answerValue: 'cefalea' }] })
+      .expect(200);
+
+    const response = await request(app.getHttpServer())
+      .get(`/v1/triage/sessions/${sessionId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const body = response.body as TriageSessionDetailResponseBody;
+    expect(body.id).toBe(sessionId);
+    expect(body.sessionId).toBe(sessionId);
+    expect(body.specialty).toBe('GENERAL_MEDICINE');
+    expect(body.status).toBe('IN_PROGRESS');
+    expect(body.isComplete).toBe(false);
+    expect(body.currentStep).toBe(2);
+    expect(body.totalSteps).toBe(5);
+    expect(body.totalQuestions).toBe(5);
+    expect(body.currentQuestionId).toBe('MG-Q2');
+    expect(body.nextQuestionId).toBe('MG-Q2');
+    expect(Array.isArray(body.questions)).toBe(true);
+    expect(body.questions.length).toBeGreaterThan(0);
+
+    const numericScaleQuestion = body.questions.find(
+      (question) => question.type === 'NUMERIC_SCALE',
+    );
+    expect(numericScaleQuestion).toBeDefined();
+    expect(numericScaleQuestion?.minValue).toBe(0);
+    expect(numericScaleQuestion?.maxValue).toBe(10);
+    expect(numericScaleQuestion?.step).toBe(1);
+
+    const choiceQuestion = body.questions.find(
+      (question) => question.type === 'SINGLE_CHOICE',
+    );
+    expect(choiceQuestion).toBeDefined();
+    expect(Array.isArray(choiceQuestion?.options)).toBe(true);
+    expect(choiceQuestion?.options?.[0]).toMatchObject({
+      id: expect.any(String),
+      label: expect.any(String),
+    });
+  });
+
+  it('GET /v1/triage/sessions/:id returns 404 for a different patient', async () => {
+    const ownerToken = await registerPatientAndLogin();
+    const outsiderToken = await registerPatientAndLogin();
+    const sessionId = await createMgSession(ownerToken);
+
+    await request(app.getHttpServer())
+      .get(`/v1/triage/sessions/${sessionId}`)
+      .set('Authorization', `Bearer ${outsiderToken}`)
+      .expect(404);
+  });
+
+  it('GET /v1/triage/sessions/:id returns 404 when session does not exist', async () => {
+    const token = await registerPatientAndLogin();
+
+    await request(app.getHttpServer())
+      .get(`/v1/triage/sessions/${new Types.ObjectId().toString()}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404);
+  });
+
   it('PATCH /v1/triage/sessions/:id/cancel cancels active session and removes it from active list', async () => {
     const token = await registerPatientAndLogin();
     const sessionId = await createMgSession(token);
@@ -408,6 +533,21 @@ describe('HU-003 Triage MG (e2e)', () => {
     const token = await registerPatientAndLogin();
     const sessionId = await createMgSession(token);
     await completeMgAnswers(token, sessionId);
+
+    const analyzeResponse = await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/analyze`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const body = analyzeResponse.body as AnalyzeTriageSessionResponseBody;
+    expect(['LOW', 'MODERATE', 'HIGH']).toContain(body.priority);
+    expect(Array.isArray(body.redFlags)).toBe(true);
+  });
+
+  it('POST /v1/triage/sessions/:id/analyze returns 200 for ODONTOLOGY sessions', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createSession(token, 'ODONTOLOGY');
+    await completeOdAnswers(token, sessionId);
 
     const analyzeResponse = await request(app.getHttpServer())
       .post(`/v1/triage/sessions/${sessionId}/analyze`)

--- a/test/triage-mg.e2e-spec.ts
+++ b/test/triage-mg.e2e-spec.ts
@@ -23,6 +23,14 @@ import { AiService } from '../src/ai/ai.service';
 
 jest.mock('dotenv/config', () => ({}));
 
+function uniqueEmail(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 10000)}@example.com`;
+}
+
+function buildStrongPassword(): string {
+  return `Aa1!${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+}
+
 describe('HU-003 Triage MG (e2e)', () => {
   const originalEnv = {
     NODE_ENV: process.env.NODE_ENV,
@@ -97,13 +105,35 @@ describe('HU-003 Triage MG (e2e)', () => {
     redFlags: Array<{ code: string }>;
   };
 
-  function uniqueEmail(prefix: string): string {
-    return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 10000)}@example.com`;
-  }
+  type ActiveTriageSessionsResponseBody = {
+    items: Array<{
+      id: string;
+      specialty: string;
+      status: string;
+      currentStep: number;
+      totalSteps: number;
+      currentQuestionId: string | null;
+      isComplete: boolean;
+      createdAt: string;
+      updatedAt: string;
+    }>;
+    total: number;
+  };
 
-  function buildStrongPassword(): string {
-    return `Aa1!${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
-  }
+  type CancelTriageSessionResponseBody = {
+    sessionId: string;
+    specialty: string;
+    status: string;
+    canceledAt: string;
+    message: string;
+  };
+
+  type HttpErrorResponseBody = {
+    statusCode: number;
+    message: string | string[];
+    existingSessionId?: string;
+    errorCode?: string;
+  };
 
   async function registerPatientAndLogin(): Promise<string> {
     const email = uniqueEmail('triage-mg');
@@ -258,13 +288,88 @@ describe('HU-003 Triage MG (e2e)', () => {
   it('POST /v1/triage/sessions returns 409 when an IN_PROGRESS session already exists', async () => {
     const token = await registerPatientAndLogin();
 
-    await createMgSession(token);
+    const existingSessionId = await createMgSession(token);
 
-    await request(app.getHttpServer())
+    const response = await request(app.getHttpServer())
       .post('/v1/triage/sessions')
       .set('Authorization', `Bearer ${token}`)
       .send({ specialty: 'GENERAL_MEDICINE' })
       .expect(409);
+
+    const body = response.body as HttpErrorResponseBody;
+    expect(body.errorCode).toBe('TRIAGE_SESSION_IN_PROGRESS');
+    expect(body.existingSessionId).toBe(existingSessionId);
+  });
+
+  it('GET /v1/triage/sessions/active returns active session progress and supports specialty filter', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createMgSession(token);
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/answers`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ answers: [{ questionId: 'MG-Q1', answerValue: 'cefalea' }] })
+      .expect(200);
+
+    const response = await request(app.getHttpServer())
+      .get('/v1/triage/sessions/active?specialty=GENERAL_MEDICINE')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const body = response.body as ActiveTriageSessionsResponseBody;
+    expect(body.total).toBe(1);
+    expect(body.items[0]).toMatchObject({
+      id: sessionId,
+      specialty: 'GENERAL_MEDICINE',
+      status: 'IN_PROGRESS',
+      totalSteps: 5,
+      currentQuestionId: 'MG-Q2',
+      isComplete: false,
+    });
+  });
+
+  it('PATCH /v1/triage/sessions/:id/cancel cancels active session and removes it from active list', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createMgSession(token);
+
+    const cancelResponse = await request(app.getHttpServer())
+      .patch(`/v1/triage/sessions/${sessionId}/cancel`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const cancelBody = cancelResponse.body as CancelTriageSessionResponseBody;
+    expect(cancelBody).toMatchObject({
+      sessionId,
+      specialty: 'GENERAL_MEDICINE',
+      status: 'CANCELED',
+      message: 'Sesion de triage cancelada correctamente',
+    });
+    expect(typeof cancelBody.canceledAt).toBe('string');
+
+    const activeResponse = await request(app.getHttpServer())
+      .get('/v1/triage/sessions/active?specialty=GENERAL_MEDICINE')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const activeBody = activeResponse.body as ActiveTriageSessionsResponseBody;
+    expect(activeBody.total).toBe(0);
+    expect(activeBody.items).toEqual([]);
+  });
+
+  it('POST /v1/triage/sessions returns 400 for invalid specialty enum', async () => {
+    const token = await registerPatientAndLogin();
+
+    const response = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ specialty: 'DENTISTRY' })
+      .expect(400);
+
+    const body = response.body as HttpErrorResponseBody;
+    expect(Array.isArray(body.message)).toBe(true);
+    expect(body.message).toContain(
+      'specialty must be one of the following values: GENERAL_MEDICINE, ODONTOLOGY',
+    );
   });
 
   it('POST /v1/triage/sessions/:id/answers returns 200 with isComplete for valid payload', async () => {

--- a/test/triage-mg.e2e-spec.ts
+++ b/test/triage-mg.e2e-spec.ts
@@ -1,0 +1,391 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { getModelToken } from '@nestjs/mongoose';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { MongoMemoryReplSet } from 'mongodb-memory-server';
+import { Model, Types } from 'mongoose';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import {
+  Consultation,
+  ConsultationDocument,
+} from '../src/consultations/schemas/consultation.schema';
+import {
+  Patient,
+  PatientDocument,
+} from '../src/patients/schemas/patient.schema';
+import {
+  TriageSession,
+  TriageSessionDocument,
+} from '../src/triage/schemas/triage-session.schema';
+import { AiService } from '../src/ai/ai.service';
+
+jest.mock('dotenv/config', () => ({}));
+
+describe('HU-003 Triage MG (e2e)', () => {
+  const originalEnv = {
+    NODE_ENV: process.env.NODE_ENV,
+    MONGODB_URI: process.env.MONGODB_URI,
+    JWT_SECRET: process.env.JWT_SECRET,
+    JWT_ACCESS_EXPIRES_IN: process.env.JWT_ACCESS_EXPIRES_IN,
+    JWT_REFRESH_EXPIRES_IN: process.env.JWT_REFRESH_EXPIRES_IN,
+    ENABLE_BOOTSTRAP_ADMIN: process.env.ENABLE_BOOTSTRAP_ADMIN,
+    AI_ENABLED: process.env.AI_ENABLED,
+    AI_PROVIDER: process.env.AI_PROVIDER,
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    GEMINI_MODEL: process.env.GEMINI_MODEL,
+    REDIS_URL: process.env.REDIS_URL,
+    REDIS_KEY_PREFIX: process.env.REDIS_KEY_PREFIX,
+    OUTBOX_DISPATCH_INTERVAL_MS: process.env.OUTBOX_DISPATCH_INTERVAL_MS,
+    DOTENV_CONFIG_PATH: process.env.DOTENV_CONFIG_PATH,
+  };
+
+  let app: INestApplication<App>;
+  let mongoServer: MongoMemoryReplSet;
+  let patientModel: Model<PatientDocument>;
+  let triageSessionModel: Model<TriageSessionDocument>;
+  let consultationModel: Model<ConsultationDocument>;
+
+  let aiResponseText = JSON.stringify({
+    priority: 'LOW',
+    summary: 'Prioridad baja, continuar observacion y seguimiento.',
+  });
+
+  const aiServiceMock = {
+    generateText: jest.fn(() =>
+      Promise.resolve({
+        provider: 'mock-gemini',
+        model: 'mock-model',
+        text: aiResponseText,
+        latencyMs: 5,
+        requestId: 'mock-request-id',
+      }),
+    ),
+    healthCheck: jest.fn(() =>
+      Promise.resolve({
+        provider: 'mock-gemini',
+        model: 'mock-model',
+        status: 'up' as const,
+        latencyMs: 5,
+        checkedAt: new Date().toISOString(),
+        degraded: false,
+        requestId: 'mock-health-id',
+      }),
+    ),
+    getReadiness: jest.fn(() => ({
+      status: 'up' as const,
+      detail: 'mock-ready',
+      degraded: false,
+    })),
+  };
+
+  type AuthSessionResponseBody = {
+    accessToken: string;
+  };
+
+  type CreateTriageSessionResponseBody = {
+    sessionId: string;
+  };
+
+  type SaveTriageAnswersResponseBody = {
+    isComplete: boolean;
+  };
+
+  type AnalyzeTriageSessionResponseBody = {
+    priority: string;
+    redFlags: Array<{ code: string }>;
+  };
+
+  function uniqueEmail(prefix: string): string {
+    return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 10000)}@example.com`;
+  }
+
+  function buildStrongPassword(): string {
+    return `Aa1!${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  async function registerPatientAndLogin(): Promise<string> {
+    const email = uniqueEmail('triage-mg');
+    const password = buildStrongPassword();
+
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Paciente',
+      lastName: 'MG',
+      email,
+      password,
+    });
+
+    const loginResponse = await request(app.getHttpServer())
+      .post('/v1/auth/patient/login')
+      .send({ email, password })
+      .expect(200);
+
+    const body = loginResponse.body as AuthSessionResponseBody;
+    return body.accessToken;
+  }
+
+  async function createMgSession(token: string): Promise<string> {
+    const response = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const body = response.body as CreateTriageSessionResponseBody;
+    return body.sessionId;
+  }
+
+  async function completeMgAnswers(
+    token: string,
+    sessionId: string,
+  ): Promise<void> {
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/answers`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        answers: [
+          { questionId: 'MG-Q1', answerValue: 'cefalea' },
+          { questionId: 'MG-Q2', answerValue: '2 dias' },
+          { questionId: 'MG-Q3', answerValue: 4 },
+          { questionId: 'MG-Q4', answerValue: 'no' },
+          { questionId: 'MG-Q5', answerValue: 'no' },
+        ],
+      })
+      .expect(200);
+  }
+
+  beforeAll(async () => {
+    jest.spyOn(ThrottlerGuard.prototype, 'canActivate').mockResolvedValue(true);
+    mongoServer = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+
+    process.env.NODE_ENV = 'test';
+    process.env.DOTENV_CONFIG_PATH = 'test/.env.does-not-exist';
+    process.env.MONGODB_URI = mongoServer.getUri();
+    process.env.JWT_SECRET = `test-secret-${Date.now()}-${Math.random().toString(36).slice(2, 16)}`;
+    process.env.JWT_ACCESS_EXPIRES_IN = '1h';
+    process.env.JWT_REFRESH_EXPIRES_IN = '7d';
+    process.env.ENABLE_BOOTSTRAP_ADMIN = 'false';
+    process.env.AI_ENABLED = 'true';
+    process.env.AI_PROVIDER = 'gemini';
+    process.env.GEMINI_API_KEY = 'mock-key';
+    process.env.GEMINI_MODEL = 'mock-model';
+    process.env.REDIS_URL = '';
+    process.env.REDIS_KEY_PREFIX = 'salud-de-una-triage-mg-e2e';
+    process.env.OUTBOX_DISPATCH_INTERVAL_MS = '50';
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { AppModule } = require('../src/app.module') as {
+      AppModule: typeof import('../src/app.module').AppModule;
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: jest.fn().mockResolvedValue(true) })
+      .overrideProvider(AiService)
+      .useValue(aiServiceMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('v1');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    patientModel = app.get<Model<PatientDocument>>(getModelToken(Patient.name));
+    triageSessionModel = app.get<Model<TriageSessionDocument>>(
+      getModelToken(TriageSession.name),
+    );
+    consultationModel = app.get<Model<ConsultationDocument>>(
+      getModelToken(Consultation.name),
+    );
+  });
+
+  beforeEach(async () => {
+    aiResponseText = JSON.stringify({
+      priority: 'LOW',
+      summary: 'Prioridad baja, continuar observacion y seguimiento.',
+    });
+
+    await Promise.all([
+      patientModel.deleteMany({}),
+      triageSessionModel.deleteMany({}),
+      consultationModel.deleteMany({}),
+    ]);
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        Reflect.deleteProperty(process.env, key);
+      } else {
+        process.env[key] = value;
+      }
+    }
+
+    jest.restoreAllMocks();
+  });
+
+  it('POST /v1/triage/sessions returns 201 with session id for GENERAL_MEDICINE', async () => {
+    const token = await registerPatientAndLogin();
+
+    const response = await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(201);
+
+    const body = response.body as CreateTriageSessionResponseBody;
+    expect(body.sessionId).toBeDefined();
+  });
+
+  it('POST /v1/triage/sessions returns 409 when an IN_PROGRESS session already exists', async () => {
+    const token = await registerPatientAndLogin();
+
+    await createMgSession(token);
+
+    await request(app.getHttpServer())
+      .post('/v1/triage/sessions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ specialty: 'GENERAL_MEDICINE' })
+      .expect(409);
+  });
+
+  it('POST /v1/triage/sessions/:id/answers returns 200 with isComplete for valid payload', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createMgSession(token);
+
+    const response = await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/answers`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        answers: [
+          { questionId: 'MG-Q1', answerValue: 'dolor de garganta' },
+          { questionId: 'MG-Q2', answerValue: '1 dia' },
+          { questionId: 'MG-Q3', answerValue: 3 },
+          { questionId: 'MG-Q4', answerValue: 'no' },
+          { questionId: 'MG-Q5', answerValue: 'no' },
+        ],
+      })
+      .expect(200);
+
+    const body = response.body as SaveTriageAnswersResponseBody;
+    expect(body.isComplete).toBe(true);
+  });
+
+  it('POST /v1/triage/sessions/:id/answers returns 404 for non-existing session', async () => {
+    const token = await registerPatientAndLogin();
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${new Types.ObjectId().toString()}/answers`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ answers: [{ questionId: 'MG-Q1', answerValue: 'dolor' }] })
+      .expect(404);
+  });
+
+  it('POST /v1/triage/sessions/:id/analyze returns 200 with priority and redFlags for complete session', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createMgSession(token);
+    await completeMgAnswers(token, sessionId);
+
+    const analyzeResponse = await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/analyze`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const body = analyzeResponse.body as AnalyzeTriageSessionResponseBody;
+    expect(['LOW', 'MODERATE', 'HIGH']).toContain(body.priority);
+    expect(Array.isArray(body.redFlags)).toBe(true);
+  });
+
+  it('POST /v1/triage/sessions/:id/analyze activates guardrail when Gemini mock returns diagnosis language', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createMgSession(token);
+    await completeMgAnswers(token, sessionId);
+
+    aiResponseText = JSON.stringify({
+      priority: 'LOW',
+      summary: 'Diagnostico de migraña. Debe tomar paracetamol.',
+    });
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/analyze`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const triageSession = await triageSessionModel
+      .findById(sessionId)
+      .lean()
+      .exec();
+    expect(triageSession?.analysis?.guardrailApplied).toBe(true);
+    expect(triageSession?.analysis?.aiSummary).toBeUndefined();
+  });
+
+  it('POST /v1/triage/sessions/:id/analyze sets HIGH priority when RF-MG-001 is triggered', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createMgSession(token);
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/answers`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        answers: [
+          {
+            questionId: 'MG-Q1',
+            answerValue: 'dolor toracico con falta de aire desde hoy',
+          },
+          { questionId: 'MG-Q2', answerValue: '1 dia' },
+          { questionId: 'MG-Q3', answerValue: 7 },
+          { questionId: 'MG-Q4', answerValue: 'no' },
+          { questionId: 'MG-Q5', answerValue: 'dificultad para respirar' },
+        ],
+      })
+      .expect(200);
+
+    aiResponseText = JSON.stringify({
+      priority: 'LOW',
+      summary: 'Prioridad baja segun evaluacion inicial.',
+    });
+
+    const analyzeResponse = await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/analyze`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const body = analyzeResponse.body as AnalyzeTriageSessionResponseBody;
+    expect(body.priority).toBe('HIGH');
+    expect(body.redFlags.some((flag) => flag.code === 'RF-MG-001')).toBe(true);
+  });
+
+  it('POST /v1/triage/sessions/:id/analyze returns 422 when session is incomplete', async () => {
+    const token = await registerPatientAndLogin();
+    const sessionId = await createMgSession(token);
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/answers`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ answers: [{ questionId: 'MG-Q1', answerValue: 'cefalea' }] })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post(`/v1/triage/sessions/${sessionId}/analyze`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(422);
+  });
+});


### PR DESCRIPTION
# feat(triage): engine centralizado de red-flags (MG) + guardrail

## Descripción
Este PR introduce la implementación catalog-driven del motor de detección de red-flags para Medicina General y un guardrail textual para las salidas de IA. Se integra el motor y el guardrail en el flujo de triage y añade pruebas unitarias y e2e focalizadas.

---

## Cambios principales
* Añadido **red-flags.engine.ts** (motor centralizado, carga de catálogo **red-flags-mg.json**)
* Añadido **red-flags-mg.json** y **guardrail-rules.json**
* Nuevo servicio **guardrail.service.ts** y tests asociados
* Actualizado **triage.service.ts** para integrar evaluación de RFs y guardrail
* Nuevos DTOs, esquemas y tests e2e: **triage-mg.e2e-spec.ts**
* Creación de **src/consultations/*** (servicio, esquema) para persistir cola de consultas desde triage
* Actualizaciones en **README.md**, assets en **nest-cli.json** y archivos de documentación relacionados

---

## Motivación
* Centralizar la lógica de detección de red-flags mediante catálogos JSON facilita mantenibilidad y revisión clínica.
* Añadir un guardrail evita que resúmenes de IA contengan diagnósticos/indicaciones inapropiadas.
* Mantener compatibilidad con comportamientos previos (p. ej. odontología) evitando regresiones.

---

## Pruebas realizadas
* **Unit tests**: cobertura para RedFlagsEngine, GuardrailService y TriageService.
* **E2E**: triage-mg.e2e-spec.ts con proveedor AI mockeado — todos los escenarios pasan.
* **Lint y build** (npm run lint, npm run build) locales — sin errores relevantes.
* **Escaneo de seguridad** (Snyk) — sin hallazgos nuevos en los archivos modificados.

---

## Checklist antes de merge
* [ ] Revisión clínica de catálogo red-flags-mg.json y guardrail-rules.json
* [ ] Revisar impacto en consumos externos (mobile / frontend)
* [ ] Ejecutar CI completo (unit + e2e) en pipeline
* [ ] (Opcional) Revisar performance de queries de la cola en ambiente con datos

---

## Notas para el revisor
* Los tests e2e y unitarios relevantes están en **triage-mg.e2e-spec.ts** y **src/triage/**.spec.ts**.
* El motor está diseñado para ser catalog-driven — añadir/modificar patrones en JSON sin tocar código.
* Para reproducciones locales: ejecutar `npm run test` y `npm run test:e2e -- --runInBand`.