### PR TITLE
feat(patients): enhance patient profile update functionality with ema…

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,18 @@ Body de update (opcional):
   "firstName": "Laura",
   "lastName": "Suarez",
   "birthDate": "1998-03-10",
-  "gender": "FEMALE"
+  "gender": "FEMALE",
+  "email": "laura@example.com",
+  "currentPassword": "ActualP@ss1",
+  "newPassword": "NuevaP@ss2"
 }
 ```
+
+Notas:
+
+- `currentPassword` es obligatoria cuando el cambio real incluye `email` o `newPassword`.
+- Cambiar `email` no revoca las refresh sessions activas.
+- Cambiar `newPassword` revoca todas las refresh sessions activas del paciente.
 
 ### 6) Bandeja admin de doctores
 

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -63,6 +63,12 @@ Registro, login, refresh, logout y sesion JWT.
 { "accessToken": "<jwt>", "refreshToken": "<jwt>" }
 ```
 
+Notas de contrato relacionadas:
+
+- `PUT /v1/patients/me` permite cambiar `email` y/o contrasena del paciente autenticado.
+- Si el paciente cambia la contrasena, `auth` revoca todas sus refresh sessions activas con `revokedReason = password_changed`.
+- Si solo cambia el correo, las refresh sessions existentes permanecen activas.
+
 ## Errores comunes y mitigacion
 
 - Cambiar contrato sin actualizar README y pruebas.

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -641,6 +641,62 @@ describe('AuthService', () => {
     expect(refreshSessionModel.updateOne).toHaveBeenCalled();
   });
 
+  it('ensureEmailIsAvailable should throw when email exists in another role', async () => {
+    patientModel.findOne.mockReturnValue(createFindOneChain(null));
+    doctorModel.findOne.mockReturnValue(createFindOneChain({ _id: 'd1' }));
+    adminModel.findOne.mockReturnValue(createFindOneChain(null));
+
+    await expect(
+      service.ensureEmailIsAvailable('doc@example.com'),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('revokeAllRefreshSessionsForUser should revoke only active sessions and accept session', async () => {
+    const dbSession: { id: string } = { id: 'mongo-session' };
+    refreshSessionModel.updateMany.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({ modifiedCount: 2 }),
+    });
+
+    await expect(
+      service.revokeAllRefreshSessionsForUser(
+        'u1',
+        UserRole.PATIENT,
+        'password_changed',
+        dbSession as never,
+      ),
+    ).resolves.toBeUndefined();
+
+    const [filter, update, options] = refreshSessionModel.updateMany.mock
+      .calls[0] as [
+      { userId: string; role: UserRole; revokedAt: { $exists: boolean } },
+      { $set: { revokedAt: Date; revokedReason: string } },
+      { session: { id: string } },
+    ];
+
+    expect(filter).toEqual({
+      userId: 'u1',
+      role: UserRole.PATIENT,
+      revokedAt: { $exists: false },
+    });
+    expect(update.$set.revokedReason).toBe('password_changed');
+    expect(update.$set.revokedAt).toBeInstanceOf(Date);
+    expect(options).toEqual({ session: dbSession });
+  });
+
+  it('revokeAllRefreshSessionsForUser should not fail when there are no active sessions', async () => {
+    refreshSessionModel.updateMany.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+    });
+
+    await expect(
+      service.revokeAllRefreshSessionsForUser(
+        'u1',
+        UserRole.PATIENT,
+        'password_changed',
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it('buildSession should revoke previous session and enforce session limit', async () => {
     configService.get.mockImplementation((key: string) => {
       if (key === 'web.refreshMaxActiveSessions') return 1;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -10,7 +10,7 @@ import { JwtService } from '@nestjs/jwt';
 import { InjectModel } from '@nestjs/mongoose';
 import * as bcrypt from 'bcrypt';
 import type { StringValue } from 'ms';
-import { Model } from 'mongoose';
+import { ClientSession, Model } from 'mongoose';
 import { Admin, AdminDocument } from '../admins/schemas/admin.schema';
 import { UserRole } from '../common/enums/user-role.enum';
 import { JwtPayload } from '../common/interfaces/jwt-payload.interface';
@@ -64,7 +64,7 @@ export class AuthService {
   ) {}
 
   async registerPatient(dto: RegisterPatientDto) {
-    await this.assertEmailDoesNotExist(dto.email);
+    await this.ensureEmailIsAvailable(dto.email);
 
     const passwordHash = await bcrypt.hash(dto.password, 12);
     const patient = await this.patientModel.create({
@@ -87,7 +87,7 @@ export class AuthService {
   }
 
   async registerDoctor(dto: RegisterDoctorDto) {
-    await this.assertEmailDoesNotExist(dto.email);
+    await this.ensureEmailIsAvailable(dto.email);
 
     if (!dto.personalId || !dto.personalId.trim()) {
       throw new BadRequestException('personalId must not be empty');
@@ -214,6 +214,34 @@ export class AuthService {
         isActive: user.isActive,
       },
     };
+  }
+
+  async ensureEmailIsAvailable(email: string): Promise<void> {
+    await this.assertEmailDoesNotExist(email);
+  }
+
+  async revokeAllRefreshSessionsForUser(
+    userId: string,
+    role: UserRole,
+    reason: string,
+    session?: ClientSession,
+  ): Promise<void> {
+    await this.refreshSessionModel
+      .updateMany(
+        {
+          userId,
+          role,
+          revokedAt: { $exists: false },
+        },
+        {
+          $set: {
+            revokedAt: new Date(),
+            revokedReason: reason,
+          },
+        },
+        session ? { session } : undefined,
+      )
+      .exec();
   }
 
   private async buildSession(

--- a/src/patients/README.md
+++ b/src/patients/README.md
@@ -49,9 +49,24 @@ Perfil del paciente y actualizacion de datos permitidos.
 ## Ejemplos de codigo/payload
 
 ```ts
-// ejemplo minimo de referencia
-export class Example {}
+// PUT /v1/patients/me
+{
+  "firstName": "Laura",
+  "lastName": "Suarez",
+  "birthDate": "1998-03-10",
+  "gender": "FEMALE",
+  "email": "laura@example.com",
+  "currentPassword": "ActualP@ss1",
+  "newPassword": "NuevaP@ss2"
+}
 ```
+
+Notas de contrato:
+
+- `email` es editable solo para `PATIENT`.
+- `currentPassword` es obligatoria cuando se cambia `email` o `newPassword`.
+- Cambio de correo: mantiene refresh sessions activas.
+- Cambio de contrasena: revoca refresh sessions activas con `revokedReason = password_changed`.
 
 ## Errores comunes y mitigacion
 

--- a/src/patients/dto/update-patient-profile.dto.ts
+++ b/src/patients/dto/update-patient-profile.dto.ts
@@ -1,9 +1,12 @@
 import {
   IsDateString,
+  IsEmail,
   IsEnum,
   IsOptional,
   IsString,
+  Matches,
   MaxLength,
+  MinLength,
 } from 'class-validator';
 import { UserGender } from '../../common/enums/user-gender.enum';
 
@@ -25,4 +28,18 @@ export class UpdatePatientProfileDto {
   @IsOptional()
   @IsEnum(UserGender)
   gender?: UserGender;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  currentPassword?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(8)
+  @Matches(/^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/)
+  newPassword?: string;
 }

--- a/src/patients/dto/update-patient-profile.dto.ts
+++ b/src/patients/dto/update-patient-profile.dto.ts
@@ -2,42 +2,42 @@ import {
   IsDateString,
   IsEmail,
   IsEnum,
-  IsOptional,
   IsString,
   Matches,
   MaxLength,
   MinLength,
+  ValidateIf,
 } from 'class-validator';
 import { UserGender } from '../../common/enums/user-gender.enum';
 
 export class UpdatePatientProfileDto {
-  @IsOptional()
+  @ValidateIf((_, value: unknown) => value !== undefined)
   @IsString()
   @MaxLength(80)
   firstName?: string;
 
-  @IsOptional()
+  @ValidateIf((_, value: unknown) => value !== undefined)
   @IsString()
   @MaxLength(80)
   lastName?: string;
 
-  @IsOptional()
+  @ValidateIf((_, value: unknown) => value !== undefined)
   @IsDateString()
   birthDate?: string;
 
-  @IsOptional()
+  @ValidateIf((_, value: unknown) => value !== undefined)
   @IsEnum(UserGender)
   gender?: UserGender;
 
-  @IsOptional()
+  @ValidateIf((_, value: unknown) => value !== undefined)
   @IsEmail()
   email?: string;
 
-  @IsOptional()
+  @ValidateIf((_, value: unknown) => value !== undefined)
   @IsString()
   currentPassword?: string;
 
-  @IsOptional()
+  @ValidateIf((_, value: unknown) => value !== undefined)
   @IsString()
   @MinLength(8)
   @Matches(/^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/)

--- a/src/patients/patients.module.ts
+++ b/src/patients/patients.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
+import { AuthModule } from '../auth/auth.module';
 import { PatientsController } from './patients.controller';
 import { PatientsService } from './patients.service';
 import { Patient, PatientSchema } from './schemas/patient.schema';
 
 @Module({
   imports: [
+    AuthModule,
     MongooseModule.forFeature([{ name: Patient.name, schema: PatientSchema }]),
   ],
   controllers: [PatientsController],

--- a/src/patients/patients.service.spec.ts
+++ b/src/patients/patients.service.spec.ts
@@ -66,6 +66,9 @@ describe('PatientsService', () => {
   };
 
   beforeEach(async () => {
+    (bcrypt.compare as jest.Mock).mockReset();
+    (bcrypt.hash as jest.Mock).mockReset();
+
     patientModel = {
       findById: jest.fn(),
     };

--- a/src/patients/patients.service.spec.ts
+++ b/src/patients/patients.service.spec.ts
@@ -1,8 +1,20 @@
-import { NotFoundException } from '@nestjs/common';
-import { getModelToken } from '@nestjs/mongoose';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { getConnectionToken, getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
+import * as bcrypt from 'bcrypt';
+import { AuthService } from '../auth/auth.service';
+import { UserRole } from '../common/enums/user-role.enum';
 import { PatientsService } from './patients.service';
 import { Patient } from './schemas/patient.schema';
+
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
 
 function createFindChain(result: unknown) {
   return {
@@ -12,23 +24,83 @@ function createFindChain(result: unknown) {
   };
 }
 
+function createDocumentQuery(result: unknown) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    session: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue(result),
+  };
+}
+
+function createPatientDocument(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  return {
+    _id: { toString: () => '507f1f77bcf86cd799439011' },
+    id: '507f1f77bcf86cd799439011',
+    firstName: 'Ana',
+    lastName: 'Lopez',
+    email: 'ana@example.com',
+    passwordHash: 'stored-hash',
+    role: UserRole.PATIENT,
+    birthDate: null,
+    gender: 'FEMALE',
+    createdAt: new Date('2026-03-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-03-02T00:00:00.000Z'),
+    save: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
 describe('PatientsService', () => {
   let service: PatientsService;
-  const patientModel = {
-    findById: jest.fn(),
-    findByIdAndUpdate: jest.fn(),
+  let patientModel: {
+    findById: jest.Mock;
+  };
+  let connection: {
+    startSession: jest.Mock;
+  };
+  let authService: {
+    ensureEmailIsAvailable: jest.Mock;
+    revokeAllRefreshSessionsForUser: jest.Mock;
   };
 
   beforeEach(async () => {
+    patientModel = {
+      findById: jest.fn(),
+    };
+
+    connection = {
+      startSession: jest.fn(),
+    };
+
+    authService = {
+      ensureEmailIsAvailable: jest.fn(),
+      revokeAllRefreshSessionsForUser: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PatientsService,
+        { provide: getConnectionToken(), useValue: connection },
         { provide: getModelToken(Patient.name), useValue: patientModel },
+        { provide: AuthService, useValue: authService },
       ],
     }).compile();
 
     service = module.get<PatientsService>(PatientsService);
   });
+
+  function mockSession() {
+    const session = {
+      withTransaction: jest.fn(async (callback: () => Promise<void>) =>
+        callback(),
+      ),
+      endSession: jest.fn().mockResolvedValue(undefined),
+    };
+    connection.startSession.mockResolvedValue(session);
+    return session;
+  }
 
   it('getMe should return patient profile', async () => {
     patientModel.findById.mockReturnValue(
@@ -37,7 +109,7 @@ describe('PatientsService', () => {
         firstName: 'Ana',
         lastName: 'Lopez',
         email: 'ana@example.com',
-        role: 'PATIENT',
+        role: UserRole.PATIENT,
         birthDate: null,
         gender: 'FEMALE',
         createdAt: new Date('2026-03-01T00:00:00.000Z'),
@@ -48,7 +120,7 @@ describe('PatientsService', () => {
     const result = await service.getMe({
       userId: '507f1f77bcf86cd799439011',
       email: 'ana@example.com',
-      role: 'PATIENT',
+      role: UserRole.PATIENT,
       isActive: true,
     });
 
@@ -56,42 +128,33 @@ describe('PatientsService', () => {
       firstName: 'Ana',
       lastName: 'Lopez',
       email: 'ana@example.com',
-      role: 'PATIENT',
+      role: UserRole.PATIENT,
     });
   });
 
   it('getMe should throw when patient not found', async () => {
     patientModel.findById.mockReturnValue(createFindChain(null));
+
     await expect(
       service.getMe({
         userId: 'missing',
         email: 'missing@example.com',
-        role: 'PATIENT',
+        role: UserRole.PATIENT,
         isActive: true,
       }),
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('updateMe should update profile and return patient', async () => {
-    patientModel.findByIdAndUpdate.mockReturnValue(
-      createFindChain({
-        _id: '507f1f77bcf86cd799439011',
-        firstName: 'Laura',
-        lastName: 'Lopez',
-        email: 'ana@example.com',
-        role: 'PATIENT',
-        birthDate: new Date('1998-03-10T00:00:00.000Z'),
-        gender: 'FEMALE',
-        createdAt: new Date('2026-03-01T00:00:00.000Z'),
-        updatedAt: new Date('2026-03-02T00:00:00.000Z'),
-      }),
-    );
+    const session = mockSession();
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
 
     const result = await service.updateMe(
       {
-        userId: '507f1f77bcf86cd799439011',
-        email: 'ana@example.com',
-        role: 'PATIENT',
+        userId: patient.id,
+        email: patient.email,
+        role: UserRole.PATIENT,
         isActive: true,
       },
       {
@@ -100,104 +163,313 @@ describe('PatientsService', () => {
       },
     );
 
+    expect(session.withTransaction).toHaveBeenCalled();
+    expect(patient.save).toHaveBeenCalled();
     expect(result).toMatchObject({
       firstName: 'Laura',
       email: 'ana@example.com',
     });
+    expect(patient.birthDate).toEqual(new Date('1998-03-10'));
+    expect(authService.revokeAllRefreshSessionsForUser).not.toHaveBeenCalled();
   });
 
-  it('updateMe should update only gender', async () => {
-    patientModel.findByIdAndUpdate.mockReturnValue(
-      createFindChain({
-        _id: '507f1f77bcf86cd799439011',
-        firstName: 'Ana',
-        lastName: 'Lopez',
-        email: 'ana@example.com',
-        role: 'PATIENT',
-        birthDate: null,
-        gender: 'MALE',
-        createdAt: new Date('2026-03-01T00:00:00.000Z'),
-        updatedAt: new Date('2026-03-02T00:00:00.000Z'),
-      }),
-    );
+  it('updateMe should update only email when currentPassword is valid', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
     const result = await service.updateMe(
       {
-        userId: '507f1f77bcf86cd799439011',
-        email: 'ana@example.com',
-        role: 'PATIENT',
+        userId: patient.id,
+        email: patient.email,
+        role: UserRole.PATIENT,
         isActive: true,
       },
       {
-        gender: 'MALE',
+        email: '  Laura@Example.com  ',
+        currentPassword: 'CurrentP@ss1',
       },
     );
-    expect(result.gender).toBe('MALE');
+
+    expect(authService.ensureEmailIsAvailable).toHaveBeenCalledWith(
+      'laura@example.com',
+    );
+    expect(result.email).toBe('laura@example.com');
+    expect(authService.revokeAllRefreshSessionsForUser).not.toHaveBeenCalled();
   });
 
-  it('updateMe should update only lastName', async () => {
-    patientModel.findByIdAndUpdate.mockReturnValue(
-      createFindChain({
-        _id: '507f1f77bcf86cd799439011',
-        firstName: 'Ana',
-        lastName: 'Martinez',
-        email: 'ana@example.com',
-        role: 'PATIENT',
-        birthDate: null,
-        gender: 'FEMALE',
-        createdAt: new Date('2026-03-01T00:00:00.000Z'),
-        updatedAt: new Date('2026-03-02T00:00:00.000Z'),
-      }),
-    );
+  it('updateMe should update profile and email together', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
     const result = await service.updateMe(
       {
-        userId: '507f1f77bcf86cd799439011',
-        email: 'ana@example.com',
-        role: 'PATIENT',
+        userId: patient.id,
+        email: patient.email,
+        role: UserRole.PATIENT,
         isActive: true,
       },
       {
-        lastName: 'Martinez',
+        firstName: 'Laura',
+        email: 'laura@example.com',
+        currentPassword: 'CurrentP@ss1',
       },
     );
-    expect(result.lastName).toBe('Martinez');
+
+    expect(result).toMatchObject({
+      firstName: 'Laura',
+      email: 'laura@example.com',
+    });
   });
 
-  it('updateMe should not update any field if dto is empty', async () => {
-    patientModel.findByIdAndUpdate.mockReturnValue(
-      createFindChain({
-        _id: '507f1f77bcf86cd799439011',
-        firstName: 'Ana',
-        lastName: 'Lopez',
-        email: 'ana@example.com',
-        role: 'PATIENT',
-        birthDate: null,
-        gender: 'FEMALE',
-        createdAt: new Date('2026-03-01T00:00:00.000Z'),
-        updatedAt: new Date('2026-03-02T00:00:00.000Z'),
-      }),
+  it('updateMe should update password and revoke refresh sessions', async () => {
+    const session = mockSession();
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    (bcrypt.compare as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    (bcrypt.hash as jest.Mock).mockResolvedValue('new-hash');
+
+    await service.updateMe(
+      {
+        userId: patient.id,
+        email: patient.email,
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      {
+        currentPassword: 'CurrentP@ss1',
+        newPassword: 'NuevaP@ss2',
+      },
     );
+
+    expect(patient.passwordHash).toBe('new-hash');
+    expect(authService.revokeAllRefreshSessionsForUser).toHaveBeenCalledWith(
+      patient.id,
+      UserRole.PATIENT,
+      'password_changed',
+      session,
+    );
+  });
+
+  it('updateMe should apply profile, email and password changes together', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+    (bcrypt.compare as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    (bcrypt.hash as jest.Mock).mockResolvedValue('new-hash');
+
     const result = await service.updateMe(
       {
-        userId: '507f1f77bcf86cd799439011',
-        email: 'ana@example.com',
-        role: 'PATIENT',
+        userId: patient.id,
+        email: patient.email,
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      {
+        firstName: 'Laura',
+        email: 'laura@example.com',
+        currentPassword: 'CurrentP@ss1',
+        newPassword: 'NuevaP@ss2',
+      },
+    );
+
+    expect(result).toMatchObject({
+      firstName: 'Laura',
+      email: 'laura@example.com',
+    });
+    expect(patient.passwordHash).toBe('new-hash');
+  });
+
+  it('updateMe should reject newPassword without currentPassword', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+
+    await expect(
+      service.updateMe(
+        {
+          userId: patient.id,
+          email: patient.email,
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        {
+          newPassword: 'NuevaP@ss2',
+        },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('updateMe should reject email change without currentPassword', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+
+    await expect(
+      service.updateMe(
+        {
+          userId: patient.id,
+          email: patient.email,
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        {
+          email: 'laura@example.com',
+        },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('updateMe should reject currentPassword without sensitive changes', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+
+    await expect(
+      service.updateMe(
+        {
+          userId: patient.id,
+          email: patient.email,
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        {
+          currentPassword: 'CurrentP@ss1',
+        },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('updateMe should reject incorrect currentPassword', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+    await expect(
+      service.updateMe(
+        {
+          userId: patient.id,
+          email: patient.email,
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        {
+          email: 'laura@example.com',
+          currentPassword: 'WrongP@ss1',
+        },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('updateMe should reject same password as current one', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+    await expect(
+      service.updateMe(
+        {
+          userId: patient.id,
+          email: patient.email,
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        {
+          currentPassword: 'CurrentP@ss1',
+          newPassword: 'CurrentP@ss1',
+        },
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('updateMe should return conflict when email is already taken', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    authService.ensureEmailIsAvailable.mockRejectedValue(
+      new ConflictException('El correo ya está registrado'),
+    );
+
+    await expect(
+      service.updateMe(
+        {
+          userId: patient.id,
+          email: patient.email,
+          role: UserRole.PATIENT,
+          isActive: true,
+        },
+        {
+          email: 'taken@example.com',
+          currentPassword: 'CurrentP@ss1',
+        },
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('updateMe should return current profile when payload is empty', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+
+    const result = await service.updateMe(
+      {
+        userId: patient.id,
+        email: patient.email,
+        role: UserRole.PATIENT,
         isActive: true,
       },
       {},
     );
-    expect(result.firstName).toBe('Ana');
-    expect(result.lastName).toBe('Lopez');
+
+    expect(result).toMatchObject({
+      firstName: 'Ana',
+      email: 'ana@example.com',
+    });
+    expect(authService.revokeAllRefreshSessionsForUser).not.toHaveBeenCalled();
+  });
+
+  it('updateMe should ignore same normalized email without revoking sessions', async () => {
+    const patient = createPatientDocument();
+    patientModel.findById.mockReturnValue(createDocumentQuery(patient));
+    mockSession();
+
+    const result = await service.updateMe(
+      {
+        userId: patient.id,
+        email: patient.email,
+        role: UserRole.PATIENT,
+        isActive: true,
+      },
+      {
+        email: '  ANA@EXAMPLE.COM  ',
+      },
+    );
+
+    expect(result.email).toBe('ana@example.com');
+    expect(authService.ensureEmailIsAvailable).not.toHaveBeenCalled();
+    expect(authService.revokeAllRefreshSessionsForUser).not.toHaveBeenCalled();
   });
 
   it('updateMe should throw when patient not found', async () => {
-    patientModel.findByIdAndUpdate.mockReturnValue(createFindChain(null));
+    patientModel.findById.mockReturnValue(createDocumentQuery(null));
+    mockSession();
 
     await expect(
       service.updateMe(
         {
           userId: 'missing',
           email: 'missing@example.com',
-          role: 'PATIENT',
+          role: UserRole.PATIENT,
           isActive: true,
         },
         { firstName: 'Laura' },

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -59,12 +59,10 @@ export class PatientsService {
           }
 
           const normalizedEmail =
-            dto.email !== undefined
-              ? this.normalizeEmail(dto.email)
-              : undefined;
+            dto.email != null ? this.normalizeEmail(dto.email) : undefined;
           const wantsEmailChange =
             normalizedEmail !== undefined && normalizedEmail !== patient.email;
-          const wantsPasswordChange = dto.newPassword !== undefined;
+          const wantsPasswordChange = dto.newPassword != null;
           const hasSensitiveChange = wantsEmailChange || wantsPasswordChange;
 
           if (wantsPasswordChange && !dto.currentPassword) {

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -98,12 +98,7 @@ export class PatientsService {
             }
 
             if (wantsPasswordChange) {
-              const samePassword = await bcrypt.compare(
-                dto.newPassword!,
-                patient.passwordHash,
-              );
-
-              if (samePassword) {
+              if (dto.newPassword === dto.currentPassword) {
                 throw new BadRequestException(
                   'La nueva contraseña debe ser diferente a la actual',
                 );

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
+  InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectConnection, InjectModel } from '@nestjs/mongoose';
@@ -50,7 +51,6 @@ export class PatientsService {
         await session.withTransaction(async () => {
           const patient = await this.patientModel
             .findById(user.userId)
-            .select('+passwordHash')
             .session(session)
             .exec();
 
@@ -86,9 +86,19 @@ export class PatientsService {
           }
 
           if (hasSensitiveChange) {
+            const patientWithPassword = await this.patientModel
+              .findById(user.userId)
+              .select('+passwordHash')
+              .session(session)
+              .exec();
+
+            if (!patientWithPassword) {
+              throw new NotFoundException('Paciente no encontrado');
+            }
+
             const currentPasswordMatches = await bcrypt.compare(
               dto.currentPassword!,
-              patient.passwordHash,
+              patientWithPassword.passwordHash,
             );
 
             if (!currentPasswordMatches) {
@@ -100,7 +110,7 @@ export class PatientsService {
             if (wantsPasswordChange) {
               const samePassword = await bcrypt.compare(
                 dto.newPassword!,
-                patient.passwordHash,
+                patientWithPassword.passwordHash,
               );
 
               if (samePassword) {
@@ -112,8 +122,9 @@ export class PatientsService {
           }
 
           if (wantsEmailChange) {
-            await this.authService.ensureEmailIsAvailable(normalizedEmail);
-            patient.email = normalizedEmail!;
+            const emailToUpdate = normalizedEmail;
+            await this.authService.ensureEmailIsAvailable(emailToUpdate);
+            patient.email = emailToUpdate;
           }
 
           if (dto.firstName !== undefined) {
@@ -175,8 +186,16 @@ export class PatientsService {
     createdAt?: Date;
     updatedAt?: Date;
   }) {
+    const patientId = patient.id ?? patient._id?.toString();
+
+    if (!patientId) {
+      throw new InternalServerErrorException(
+        'No fue posible construir el perfil del paciente',
+      );
+    }
+
     return {
-      id: patient.id ?? patient._id?.toString() ?? '',
+      id: patientId,
       firstName: patient.firstName,
       lastName: patient.lastName,
       email: patient.email,

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -1,6 +1,14 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectConnection, InjectModel } from '@nestjs/mongoose';
+import * as bcrypt from 'bcrypt';
+import { Connection, Model } from 'mongoose';
+import { AuthService } from '../auth/auth.service';
+import { UserRole } from '../common/enums/user-role.enum';
 import { RequestUser } from '../common/interfaces/request-user.interface';
 import { UpdatePatientProfileDto } from './dto/update-patient-profile.dto';
 import { Patient, PatientDocument } from './schemas/patient.schema';
@@ -8,8 +16,11 @@ import { Patient, PatientDocument } from './schemas/patient.schema';
 @Injectable()
 export class PatientsService {
   constructor(
+    @InjectConnection()
+    private readonly connection: Connection,
     @InjectModel(Patient.name)
     private readonly patientModel: Model<PatientDocument>,
+    private readonly authService: AuthService,
   ) {}
 
   async getMe(user: RequestUser) {
@@ -25,8 +36,147 @@ export class PatientsService {
       throw new NotFoundException('Paciente no encontrado');
     }
 
+    return this.toProfileResponse(patient);
+  }
+
+  async updateMe(user: RequestUser, dto: UpdatePatientProfileDto) {
+    try {
+      const session = await this.connection.startSession();
+      try {
+        let response:
+          | ReturnType<PatientsService['toProfileResponse']>
+          | undefined;
+
+        await session.withTransaction(async () => {
+          const patient = await this.patientModel
+            .findById(user.userId)
+            .select('+passwordHash')
+            .session(session)
+            .exec();
+
+          if (!patient) {
+            throw new NotFoundException('Paciente no encontrado');
+          }
+
+          const normalizedEmail =
+            dto.email !== undefined
+              ? this.normalizeEmail(dto.email)
+              : undefined;
+          const wantsEmailChange =
+            normalizedEmail !== undefined && normalizedEmail !== patient.email;
+          const wantsPasswordChange = dto.newPassword !== undefined;
+          const hasSensitiveChange = wantsEmailChange || wantsPasswordChange;
+
+          if (wantsPasswordChange && !dto.currentPassword) {
+            throw new BadRequestException(
+              'Debes enviar la contraseña actual para cambiar la contraseña',
+            );
+          }
+
+          if (wantsEmailChange && !dto.currentPassword) {
+            throw new BadRequestException(
+              'Debes enviar la contraseña actual para cambiar el correo',
+            );
+          }
+
+          if (dto.currentPassword && !hasSensitiveChange) {
+            throw new BadRequestException(
+              'La contraseña actual solo se permite cuando cambias correo o contraseña',
+            );
+          }
+
+          if (hasSensitiveChange) {
+            const currentPasswordMatches = await bcrypt.compare(
+              dto.currentPassword!,
+              patient.passwordHash,
+            );
+
+            if (!currentPasswordMatches) {
+              throw new BadRequestException(
+                'La contraseña actual es incorrecta',
+              );
+            }
+
+            if (wantsPasswordChange) {
+              const samePassword = await bcrypt.compare(
+                dto.newPassword!,
+                patient.passwordHash,
+              );
+
+              if (samePassword) {
+                throw new BadRequestException(
+                  'La nueva contraseña debe ser diferente a la actual',
+                );
+              }
+            }
+          }
+
+          if (wantsEmailChange) {
+            await this.authService.ensureEmailIsAvailable(normalizedEmail);
+            patient.email = normalizedEmail!;
+          }
+
+          if (dto.firstName !== undefined) {
+            patient.firstName = dto.firstName;
+          }
+
+          if (dto.lastName !== undefined) {
+            patient.lastName = dto.lastName;
+          }
+
+          if (dto.birthDate !== undefined) {
+            patient.birthDate = new Date(dto.birthDate);
+          }
+
+          if (dto.gender !== undefined) {
+            patient.gender = dto.gender;
+          }
+
+          if (wantsPasswordChange) {
+            patient.passwordHash = await bcrypt.hash(dto.newPassword!, 12);
+          }
+
+          await patient.save({ session });
+
+          if (wantsPasswordChange) {
+            await this.authService.revokeAllRefreshSessionsForUser(
+              patient.id,
+              UserRole.PATIENT,
+              'password_changed',
+              session,
+            );
+          }
+
+          response = this.toProfileResponse(patient);
+        });
+
+        return response!;
+      } finally {
+        await session.endSession();
+      }
+    } catch (error: unknown) {
+      if (this.isDuplicateKeyError(error, 'email')) {
+        throw new ConflictException('El correo ya está registrado');
+      }
+
+      throw error;
+    }
+  }
+
+  private toProfileResponse(patient: {
+    _id?: { toString(): string };
+    id?: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    role: UserRole;
+    birthDate?: Date | null;
+    gender?: string;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
     return {
-      id: patient._id.toString(),
+      id: patient.id ?? patient._id?.toString() ?? '',
       firstName: patient.firstName,
       lastName: patient.lastName,
       email: patient.email,
@@ -38,40 +188,25 @@ export class PatientsService {
     };
   }
 
-  async updateMe(user: RequestUser, dto: UpdatePatientProfileDto) {
-    const updatedPatient = await this.patientModel
-      .findByIdAndUpdate(
-        user.userId,
-        {
-          ...(dto.firstName !== undefined ? { firstName: dto.firstName } : {}),
-          ...(dto.lastName !== undefined ? { lastName: dto.lastName } : {}),
-          ...(dto.birthDate !== undefined
-            ? { birthDate: new Date(dto.birthDate) }
-            : {}),
-          ...(dto.gender !== undefined ? { gender: dto.gender } : {}),
-        },
-        { returnDocument: 'after', runValidators: true },
-      )
-      .select(
-        'firstName lastName email role birthDate gender createdAt updatedAt',
-      )
-      .lean()
-      .exec();
+  private normalizeEmail(email: string): string {
+    return email.trim().toLowerCase();
+  }
 
-    if (!updatedPatient) {
-      throw new NotFoundException('Paciente no encontrado');
+  private isDuplicateKeyError(error: unknown, field: string): boolean {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as Record<string, unknown>).code === 11000
+    ) {
+      const keyPattern = (error as Record<string, unknown>).keyPattern;
+      return (
+        typeof keyPattern === 'object' &&
+        keyPattern !== null &&
+        field in (keyPattern as Record<string, unknown>)
+      );
     }
 
-    return {
-      id: updatedPatient._id.toString(),
-      firstName: updatedPatient.firstName,
-      lastName: updatedPatient.lastName,
-      email: updatedPatient.email,
-      role: updatedPatient.role,
-      birthDate: updatedPatient.birthDate,
-      gender: updatedPatient.gender,
-      createdAt: updatedPatient.createdAt,
-      updatedAt: updatedPatient.updatedAt,
-    };
+    return false;
   }
 }

--- a/test/e1.e2e-spec.ts
+++ b/test/e1.e2e-spec.ts
@@ -661,6 +661,27 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
       .expect(400);
   });
 
+  it('PUT /v1/patients/me should return 400 when email is null', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Lina',
+      lastName: 'Suarez',
+      email: 'patient-null-email@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const patientToken = await login(
+      'patient-null-email@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    await request(app.getHttpServer())
+      .put('/v1/patients/me')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ email: null })
+      .expect(400);
+  });
+
   it('PUT /v1/patients/me should change email with current password and keep refresh session usable', async () => {
     await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
       firstName: 'Lina',

--- a/test/e1.e2e-spec.ts
+++ b/test/e1.e2e-spec.ts
@@ -151,6 +151,15 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
     password: string,
     client: 'patient' | 'staff',
   ): Promise<string> {
+    const body = await loginSession(email, password, client);
+    return body.accessToken;
+  }
+
+  async function loginSession(
+    email: string,
+    password: string,
+    client: 'patient' | 'staff',
+  ): Promise<AuthSessionResponseBody> {
     const response = await request(app.getHttpServer())
       .post(
         client === 'patient'
@@ -160,8 +169,7 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
       .send({ email, password })
       .expect(200);
 
-    const body = response.body as AuthSessionResponseBody;
-    return body.accessToken;
+    return response.body as AuthSessionResponseBody;
   }
 
   async function registerDoctor(email: string): Promise<string> {
@@ -611,6 +619,212 @@ describe('Epic 1 HU-001/HU-002 (e2e)', () => {
       firstName: 'Laura',
       email: 'patient-update@example.com',
     });
+  });
+
+  it('PUT /v1/patients/me should return 401 without token', async () => {
+    await request(app.getHttpServer())
+      .put('/v1/patients/me')
+      .send({ firstName: 'Laura' })
+      .expect(401);
+  });
+
+  it('PUT /v1/patients/me should return 403 for non-patient role', async () => {
+    const doctorEmail = 'patient-update-forbidden@example.com';
+    await registerDoctor(doctorEmail);
+    const doctorToken = await login(doctorEmail, 'StrongP@ss1', 'staff');
+
+    await request(app.getHttpServer())
+      .put('/v1/patients/me')
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ firstName: 'Laura' })
+      .expect(403);
+  });
+
+  it('PUT /v1/patients/me should return 400 for incoherent password payload', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Lina',
+      lastName: 'Suarez',
+      email: 'patient-incoherent@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const patientToken = await login(
+      'patient-incoherent@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    await request(app.getHttpServer())
+      .put('/v1/patients/me')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({ currentPassword: 'StrongP@ss1' })
+      .expect(400);
+  });
+
+  it('PUT /v1/patients/me should change email with current password and keep refresh session usable', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Lina',
+      lastName: 'Suarez',
+      email: 'patient-email-change@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const session = await loginSession(
+      'patient-email-change@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    const updateResponse = await request(app.getHttpServer())
+      .put('/v1/patients/me')
+      .set('Authorization', `Bearer ${session.accessToken}`)
+      .send({
+        email: 'patient-email-new@example.com',
+        currentPassword: 'StrongP@ss1',
+      })
+      .expect(200);
+
+    expect(updateResponse.body).toMatchObject({
+      email: 'patient-email-new@example.com',
+    });
+
+    await request(app.getHttpServer())
+      .post('/v1/auth/patient/login')
+      .send({
+        email: 'patient-email-change@example.com',
+        password: 'StrongP@ss1',
+      })
+      .expect(401);
+
+    await request(app.getHttpServer())
+      .post('/v1/auth/patient/login')
+      .send({
+        email: 'patient-email-new@example.com',
+        password: 'StrongP@ss1',
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/v1/auth/me')
+      .set('Authorization', `Bearer ${session.accessToken}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toMatchObject({
+          user: {
+            email: 'patient-email-new@example.com',
+            role: 'PATIENT',
+          },
+        });
+      });
+
+    await request(app.getHttpServer())
+      .post('/v1/auth/refresh')
+      .send({ refreshToken: session.refreshToken })
+      .expect(200)
+      .expect((res) => {
+        const body = res.body as AuthSessionResponseBody;
+        expect(body.user.email).toBe('patient-email-new@example.com');
+      });
+  });
+
+  it('PUT /v1/patients/me should return 400 when current password is incorrect', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Lina',
+      lastName: 'Suarez',
+      email: 'patient-email-bad-pass@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const patientToken = await login(
+      'patient-email-bad-pass@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    await request(app.getHttpServer())
+      .put('/v1/patients/me')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({
+        email: 'patient-email-bad-pass-new@example.com',
+        currentPassword: 'WrongP@ss1',
+      })
+      .expect(400);
+  });
+
+  it('PUT /v1/patients/me should return 409 when new email is already taken', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Lina',
+      lastName: 'Suarez',
+      email: 'patient-email-taken-1@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Marta',
+      lastName: 'Rojas',
+      email: 'patient-email-taken-2@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const patientToken = await login(
+      'patient-email-taken-1@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    await request(app.getHttpServer())
+      .put('/v1/patients/me')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send({
+        email: 'patient-email-taken-2@example.com',
+        currentPassword: 'StrongP@ss1',
+      })
+      .expect(409);
+  });
+
+  it('PUT /v1/patients/me should change password and revoke previous refresh sessions', async () => {
+    await request(app.getHttpServer()).post('/v1/auth/patient/register').send({
+      firstName: 'Lina',
+      lastName: 'Suarez',
+      email: 'patient-password-change@example.com',
+      password: 'StrongP@ss1',
+    });
+
+    const session = await loginSession(
+      'patient-password-change@example.com',
+      'StrongP@ss1',
+      'patient',
+    );
+
+    await request(app.getHttpServer())
+      .put('/v1/patients/me')
+      .set('Authorization', `Bearer ${session.accessToken}`)
+      .send({
+        currentPassword: 'StrongP@ss1',
+        newPassword: 'NuevaP@ss2',
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post('/v1/auth/patient/login')
+      .send({
+        email: 'patient-password-change@example.com',
+        password: 'StrongP@ss1',
+      })
+      .expect(401);
+
+    await request(app.getHttpServer())
+      .post('/v1/auth/patient/login')
+      .send({
+        email: 'patient-password-change@example.com',
+        password: 'NuevaP@ss2',
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post('/v1/auth/refresh')
+      .send({ refreshToken: session.refreshToken })
+      .expect(401);
   });
 
   it('POST /v1/auth/refresh should rotate session when refresh token is provided', async () => {


### PR DESCRIPTION
Se completa la edición de perfil del paciente en `PUT /v1/patients/me` en el backend.
Ahora el paciente autenticado puede:
- actualizar `firstName`, `lastName`, `birthDate`, `gender` y `email`
- cambiar su contraseña desde el mismo endpoint
El cambio mantiene el alcance solo para `PATIENT`, no crea endpoints nuevos y no agrega campos nuevos persistidos en `Patient`.

## Cambios principales
- Se extendió `UpdatePatientProfileDto` para aceptar `email`, `currentPassword` y `newPassword`.
- Se reemplazó el flujo de `findByIdAndUpdate` por carga de documento + transacción Mongo en `PatientsService`.
- Se exige `currentPassword` cuando el cambio real incluye `email` o `newPassword`.
- Se valida que la contraseña actual sea correcta antes de aplicar cambios sensibles.
- Se impide reutilizar la contraseña actual como nueva contraseña.
- Se reutiliza la validación global de disponibilidad de correo entre `patients`, `doctors` y `admins`.
- Al cambiar contraseña se revocan todas las refresh sessions activas del paciente con `revokedReason = password_changed`.
- Al cambiar solo el correo, las refresh sessions activas se mantienen.
- Se actualizó la documentación del endpoint en los README correspondientes.

## Comportamiento esperado
- `PUT /v1/patients/me` sigue respondiendo el perfil seguro del paciente.
- El cambio de correo requiere `currentPassword`.
- El cambio de contraseña requiere `currentPassword` y `newPassword`.
- El access token actual sigue siendo válido hasta expirar.
- Los refresh tokens previos al cambio de contraseña quedan inválidos.
- Los refresh tokens previos al cambio de correo siguen funcionando.

## Pruebas
Se agregaron/actualizaron pruebas unitarias y e2e para cubrir:
- actualización solo de perfil
- actualización de correo
- cambio de contraseña
- payloads incoherentes
- contraseña actual incorrecta
- correo duplicado
- login con correo viejo/nuevo
- refresh token válido tras cambio de correo
- refresh token inválido tras cambio de contraseña